### PR TITLE
stdlib: Format exceptions very carefully

### DIFF
--- a/Source/Libraries/Standard/Exception.rogue
+++ b/Source/Libraries/Standard/Exception.rogue
@@ -25,9 +25,12 @@ class Exception [requisite]
       return message
 
     method format->String [requisite]
-      local st = stack_trace->String.trimmed
+      local st = stack_trace->String
+      if (st is null) st = "No stack trace"
+      st = st.trimmed
       if (st.count) st = "\n" + st
-      return "$$" (this, st)
+      local self = select{this is null:"Unknown" || this->String}
+      return "$$" (self, st)
 endClass
 
 class Error : Exception;


### PR DESCRIPTION
This tries to ensure that even if things are not operating as expected
(which seems fair in the case of Exceptions!), formatting an exception
will not result in dereferencing a null pointer.

I think you've got changes in progress on develop.  Let me know if you want me to rebase this.