### PR TITLE
Global vars in routines, --compile-arg, initialization improvements, etc.

### DIFF
--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -1056,6 +1056,9 @@ augment Program
       writer.println( "{" )
       writer.indent += 2
 
+      # Call configure; if it has already been called, this won't do anything.
+      writer.println( "Rogue_configure(0, NULL);" )
+
       # Call all init_class() methods
       forEach (type in type_list)
         if (type.is_used)

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -2338,6 +2338,11 @@ augment Method
 
     method is_c_compatible ( )->Logical
       # Returns true if C linkage is okay for this method
+      # In theory, this should be okay for compounds that don't has_object_references...
+      # except that their constructors keep them from being POD types.  They should
+      # actually probably work fine *anyway*, and we could also rewrite compounds
+      # to not use constructors (and use factories and aggregation initialization
+      # instead).  But for now... compounds are out.
       if (return_type and return_type.is_compound) return false
       if (parameters)
         forEach (p in parameters)

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -1865,6 +1865,10 @@ augment RogueC
           endIf
         endIf
 
+        if (RogueC.compiler_options.count)
+          compiler_name += " " + " ".join(RogueC.compiler_options)
+        endIf
+
         local exe = output_filepath
         if (exe.contains('/'))
           exe = File.path(exe) + "/" + File.filename(exe).to_lowercase

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -1052,6 +1052,9 @@ augment Program
       endIf
 
       # launch()
+      writer.println @|#ifdef ROGUE_AUTO_LAUNCH
+                      |__attribute__((constructor))
+                      |#endif
       writer.println( "void Rogue_launch()" )
       writer.println( "{" )
       writer.indent += 2

--- a/Source/RogueC/Parser.rogue
+++ b/Source/RogueC/Parser.rogue
@@ -240,7 +240,7 @@ class Parser
       local t = peek # 'routine'
       local original_type = this_type
       this_type = Program.get_type_reference( peek, "Global" )
-      parse_method( true, &first_token=TokenType.keyword_routine)
+      parse_method( false, &first_token=TokenType.keyword_routine)
       must_consume( TokenType.keyword_endRoutine )
       if (not this_method and not this_type.method_templates)
         throw t.error("Failed to parse routine")

--- a/Source/RogueC/RogueC.rogue
+++ b/Source/RogueC/RogueC.rogue
@@ -81,6 +81,7 @@ class RogueC [singleton]
 
     compile_output    : Logical
     compiler_name     : String
+    compiler_options  = String[]
     execute_args      : String
 
     package_name      : String
@@ -152,6 +153,13 @@ class RogueC [singleton]
                    |    language-specific default is used - for a C++ code target this is the
                    |    Makefile-default $(CXX) compiler with certain options - see DEFAULT_CXX in
                    |    the Rogue source folder's Makefile.
+                   |
+                   |  --compile-arg[=<addendum to compiler invocation>]
+                   |    Like --compile, this passes the output of compiling the .rogue code to, e.g,
+                   |    the C++ compiler.  There are two differences.  First, it does not imply
+                   |    the --main option.  Second, the argument is appended to the current compiler
+                   |    commandline rather than replacing it.  You may specify this more than once,
+                   |    and you may specify it in conjunction with --compile.
                    |
                    |  --debug
                    |    Enables exception stack traces.
@@ -449,6 +457,10 @@ class RogueC [singleton]
               generate_main = true
               compile_output = true
               if (value.count) compiler_name = value
+
+            case "--compile-arg"
+              compile_output = true
+              if (value.count) compiler_options.add( value )
 
             case "--execute"
               generate_main = true

--- a/Source/RogueC/Scope.rogue
+++ b/Source/RogueC/Scope.rogue
@@ -735,7 +735,7 @@ class CandidateMethods
               (base_name,access.name,scope_type) )
           else
             throw access.t.error( ''No such method or variable "$" exists in current scope of type $$.'' (access.name,scope_type, ...
-                                  select{inferring_templates: ", and no existing template method could be instantiated via inference" || ""}) )
+                                  select{inferring_templates: ", and no existing method template could be instantiated via inference" || ""}) )
           endIf
 
         elseIf (require_compatible)


### PR DESCRIPTION
Routines:
Routines are now non-global methods of Global instead of global methods of global.  This makes global variables accessible from routines again.  This could probably be optimized.

--compile-args:
Helps for non-default compiles (e.g., adding flags like -O3).

Initialization stuff:
- Rogue_launch() now calls Rogue_configure().  If it has already been called, this does nothing.  If it hasn't, it prevents a segfault.  So basically, you can now initialize Rogue with a single call instead of two.
- If you pass -DROGUE_AUTO_LAUNCH to the C++ compiler, Rogue_launch() gets the "constructor" attribute.  In particular, this means if you compile to a shared library, Rogue_launch() is called automatically when it gets loaded (at least with clang and gcc).

Minor error message fix and an extended comment.