### PR TITLE
auto-mt collector, bug fixes, new features, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ Source/DocGen/Build
 Local.mk
 Hello.rogue
 .rogo
+*.patch
+*.diff

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ Source/RogueC/Build/Rogo.cpp: $(ROGUEC_SRC) Source/Tools/Rogo.rogue
 	@echo "Recompiling Rogo.rogue -> Rogo.cpp..."
 	@echo -------------------------------------------------------------------------------
 	mkdir -p Source/RogueC/Build
-	roguec Source/Tools/Rogo.rogue --gc=manual --main --output=Source/RogueC/Build/Rogo $(ROGUEC_ROGUE_FLAGS)
+	roguec Source/Tools/Rogo.rogue --threads=pthreads --gc=manual --main --output=Source/RogueC/Build/Rogo $(ROGUEC_ROGUE_FLAGS)
 
 Programs/RogueC/$(PLATFORM)/roguec: Source/RogueC/Build/RogueC.cpp
 	@echo -------------------------------------------------------------------------------
@@ -125,7 +125,7 @@ Programs/RogueC/$(PLATFORM)/rogo: Source/RogueC/Build/Rogo.cpp
 	@echo "Compiling Rogo.cpp -> Programs/RogueC/$(PLATFORM)/rogo..."
 	@echo -------------------------------------------------------------------------------
 	mkdir -p Programs
-	$(CXX) $(ROGUEC_CPP_FLAGS) -DDEFAULT_CXX="$(DEFAULT_CXX)" Source/RogueC/Build/Rogo.cpp -o Programs/RogueC/$(PLATFORM)/rogo
+	$(CXX) -pthread $(ROGUEC_CPP_FLAGS) -DDEFAULT_CXX="$(DEFAULT_CXX)" Source/RogueC/Build/Rogo.cpp -o Programs/RogueC/$(PLATFORM)/rogo
 
 libraries:
 	@mkdir -p Programs/RogueC/$(PLATFORM)

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -84,8 +84,19 @@ static int Rogue_mt_tc = 0; // Thread count.  Always set under above lock.
 static void Rogue_thread_register ()
 {
   pthread_mutex_lock(&Rogue_mt_thread_mutex);
+  int n = (int)Rogue_mt_tc;
   ++Rogue_mt_tc;
   pthread_mutex_unlock(&Rogue_mt_thread_mutex);
+  char name[64];
+  sprintf(name, "Thread-%i", n); // Nice names are good for valgrind
+
+#if ROGUE_PLATFORM_MACOS
+  pthread_setname_np(name);
+#elif __linux__
+  pthread_setname_np(pthread_self(), name);
+#endif
+// It should be possible to get thread names working on lots of other
+// platforms too.  The functions just vary a bit.
 }
 
 static void Rogue_thread_unregister ()

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -163,6 +163,9 @@ pthread_mutex_t Rogue_thread_singleton_lock;
 //-----------------------------------------------------------------------------
 //  GC
 //-----------------------------------------------------------------------------
+#define ROGUE_GC_SOA_LOCK
+#define ROGUE_GC_SOA_UNLOCK
+
 int Rogue_allocation_bytes_until_gc = Rogue_gc_threshold;
 #define ROGUE_GC_COUNT_BYTES(__x) Rogue_allocation_bytes_until_gc -= (__x);
 #define ROGUE_GC_AT_THRESHOLD (Rogue_allocation_bytes_until_gc <= 0)
@@ -892,6 +895,8 @@ void* RogueAllocator_allocate( RogueAllocator* THIS, int size )
     return mem;
   }
 
+  ROGUE_GC_SOA_LOCK;
+
   size = (size > 0) ? (size + ROGUEMM_GRANULARITY_MASK) & ~ROGUEMM_GRANULARITY_MASK : ROGUEMM_GRANULARITY_SIZE;
 
   ROGUE_GC_COUNT_BYTES(size);
@@ -903,6 +908,7 @@ void* RogueAllocator_allocate( RogueAllocator* THIS, int size )
   {
     //printf( "found free object\n");
     THIS->available_objects[slot] = obj->next_object;
+    ROGUE_GC_SOA_UNLOCK;
     return obj;
   }
 
@@ -912,7 +918,11 @@ void* RogueAllocator_allocate( RogueAllocator* THIS, int size )
   if (THIS->pages )
   {
     obj = (RogueObject*) RogueAllocationPage_allocate( THIS->pages, size );
-    if (obj) return obj;
+    if (obj)
+    {
+      ROGUE_GC_SOA_UNLOCK;
+      return obj;
+    }
 
     // Not enough room on allocation page.  Allocate any smaller blocks
     // we're able to and then move on to a new page.
@@ -935,7 +945,9 @@ void* RogueAllocator_allocate( RogueAllocator* THIS, int size )
 
   // New page; this will work for sure.
   THIS->pages = RogueAllocationPage_create( THIS->pages );
-  return RogueAllocationPage_allocate( THIS->pages, size );
+  void * r = RogueAllocationPage_allocate( THIS->pages, size );
+  ROGUE_GC_SOA_UNLOCK;
+  return r;
 }
 
 #if ROGUE_GC_MODE_BOEHM

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -703,11 +703,13 @@ RogueAllocationPage* RogueAllocationPage_create( RogueAllocationPage* next_page 
   return result;
 }
 
+#if 0 // This is currently done statically.  Code likely to be removed.
 RogueAllocationPage* RogueAllocationPage_delete( RogueAllocationPage* THIS )
 {
   if (THIS) ROGUE_DEL_BYTES( THIS );
   return 0;
 };
+#endif
 
 void* RogueAllocationPage_allocate( RogueAllocationPage* THIS, int size )
 {
@@ -730,6 +732,7 @@ void* RogueAllocationPage_allocate( RogueAllocationPage* THIS, int size )
 //-----------------------------------------------------------------------------
 //  RogueAllocator
 //-----------------------------------------------------------------------------
+#if 0 // This is currently done statically.  Code likely to be removed.
 RogueAllocator* RogueAllocator_create()
 {
   RogueAllocator* result = (RogueAllocator*) ROGUE_NEW_BYTES( sizeof(RogueAllocator) );
@@ -749,6 +752,7 @@ RogueAllocator* RogueAllocator_delete( RogueAllocator* THIS )
   }
   return 0;
 }
+#endif
 
 void* RogueAllocator_allocate( RogueAllocator* THIS, int size )
 {

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -1471,11 +1471,21 @@ bool Rogue_collect_garbage( bool forced )
 
   return GC_collect_a_little();
 }
-#else
+#else // Auto or manual
+
+static inline void Rogue_collect_garbage_real(void);
+
 bool Rogue_collect_garbage( bool forced )
 {
-
   if (!forced && !Rogue_gc_requested & !ROGUE_GC_AT_THRESHOLD) return false;
+
+  Rogue_collect_garbage_real();
+
+  return true;
+}
+
+static inline void Rogue_collect_garbage_real()
+{
   Rogue_gc_requested = false;
   ++ Rogue_gc_count;
 
@@ -1492,9 +1502,8 @@ bool Rogue_collect_garbage( bool forced )
   }
 
   Rogue_on_gc_end.call();
-
-  return true;
 }
+
 #endif
 
 void Rogue_quit()

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -116,11 +116,6 @@ RogueArray* RogueType_create_array( int count, int element_size, bool is_referen
 
   RogueArray* array = (RogueArray*) RogueAllocator_allocate_object( RogueTypeArray->allocator, RogueTypeArray, total_size, element_type_index);
 
-#if ROGUE_GC_MODE_BOEHM
-  // Already zeroed.
-#else
-  memset( array->as_bytes, 0, data_size );
-#endif
   array->count = count;
   array->element_size = element_size;
   array->is_reference_array = is_reference_array;

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -1440,7 +1440,6 @@ bool Rogue_collect_garbage( bool forced )
 #else
 bool Rogue_collect_garbage( bool forced )
 {
-  int i;
 
   if (Rogue_allocation_bytes_until_gc > 0 && !forced && !Rogue_gc_requested) return false;
   Rogue_gc_requested = false;
@@ -1453,7 +1452,7 @@ bool Rogue_collect_garbage( bool forced )
 
   Rogue_trace();
 
-  for (i=0; i<Rogue_allocator_count; ++i)
+  for (int i=0; i<Rogue_allocator_count; ++i)
   {
     RogueAllocator_collect_garbage( &Rogue_allocators[i] );
   }

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -881,14 +881,14 @@ RogueAllocator* RogueAllocator_delete( RogueAllocator* THIS )
 
 void* RogueAllocator_allocate( RogueAllocator* THIS, int size )
 {
-#if ROGUE_GC_MODE_AUTO
+#if ROGUE_GC_MODE_AUTO_MT
   Rogue_collect_garbage();
 #endif
   if (size > ROGUEMM_SMALL_ALLOCATION_SIZE_LIMIT)
   {
     ROGUE_GC_COUNT_BYTES(size);
     void * mem = ROGUE_NEW_BYTES(size);
-#if ROGUE_GC_MODE_AUTO
+#if ROGUE_GC_MODE_AUTO_ANY
     if (!mem)
     {
       // Try hard!

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -80,9 +80,12 @@ RogueWeakReference* Rogue_weak_references = 0;
 // Thread mutex locks around creation and destruction of threads
 static pthread_mutex_t Rogue_mt_thread_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int Rogue_mt_tc = 0; // Thread count.  Always set under above lock.
+static std::atomic_bool Rogue_mt_terminating(false); // True when terminating.
 
 static void Rogue_thread_register ()
 {
+  // If we're shutting down, no new threads!
+  if (Rogue_mt_terminating.load()) pthread_exit(NULL);
   pthread_mutex_lock(&Rogue_mt_thread_mutex);
   int n = (int)Rogue_mt_tc;
   ++Rogue_mt_tc;
@@ -111,6 +114,7 @@ static void Rogue_thread_unregister ()
 
 void Rogue_threads_wait_for_all ()
 {
+  Rogue_mt_terminating = true;
   int wait = 2; // Initial Xms
   int wait_step = 1;
   while (true)

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -168,6 +168,8 @@ int Rogue_allocation_bytes_until_gc = Rogue_gc_threshold;
 #define ROGUE_GC_AT_THRESHOLD (Rogue_allocation_bytes_until_gc <= 0)
 #define ROGUE_GC_RESET_COUNT Rogue_allocation_bytes_until_gc = Rogue_gc_threshold;
 
+#define ROGUE_LINKED_LIST_INSERT(__OLD,__NEW,__NEW_NEXT) do {__NEW_NEXT = __OLD; __OLD = __NEW;} while(false)
+
 //-----------------------------------------------------------------------------
 //  RogueDebugTrace
 //-----------------------------------------------------------------------------
@@ -1036,18 +1038,17 @@ RogueObject* RogueAllocator_allocate_object( RogueAllocator* THIS, RogueType* of
 
   memset( obj, 0, size );
 
+  obj->type = of_type;
+  obj->object_size = size;
+
   if (of_type->on_cleanup_fn)
   {
-    obj->next_object = THIS->objects_requiring_cleanup;
-    THIS->objects_requiring_cleanup = obj;
+    ROGUE_LINKED_LIST_INSERT(THIS->objects_requiring_cleanup, obj, obj->next_object);
   }
   else
   {
-    obj->next_object = THIS->objects;
-    THIS->objects = obj;
+    ROGUE_LINKED_LIST_INSERT(THIS->objects, obj, obj->next_object);
   }
-  obj->type = of_type;
-  obj->object_size = size;
 
   return obj;
 }

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -1434,7 +1434,7 @@ void* RogueAllocator_free( RogueAllocator* THIS, void* data, int size )
     ROGUE_GCDEBUG_STATEMENT(memset(data,0,size));
     if (size > ROGUEMM_SMALL_ALLOCATION_SIZE_LIMIT)
     {
-      // When debugging GC, it can be very useful to lock the object types of
+      // When debugging GC, it can be very useful to log the object types of
       // freed objects.  When valgrind points out access to freed memory, you
       // can then see what it was.
       #if 0

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -103,7 +103,9 @@ static void Rogue_thread_register ()
 
 static void Rogue_thread_unregister ()
 {
+  ROGUE_EXIT;
   pthread_mutex_lock(&Rogue_mt_thread_mutex);
+  ROGUE_ENTER;
   --Rogue_mt_tc;
   pthread_mutex_unlock(&Rogue_mt_thread_mutex);
 }
@@ -114,6 +116,7 @@ static void Rogue_thread_unregister ()
 void Rogue_threads_wait_for_all ()
 {
   Rogue_mt_terminating = true;
+  ROGUE_EXIT;
   int wait = 2; // Initial Xms
   int wait_step = 1;
   while (true)
@@ -129,6 +132,7 @@ void Rogue_threads_wait_for_all ()
     wait_step++;
     if (!(wait_step % 15) && (wait < 500)) wait *= 2; // Max backoff ~500ms
   }
+  ROGUE_ENTER;
 }
 
 #else

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -57,6 +57,7 @@
 //-----------------------------------------------------------------------------
 bool               Rogue_gc_logging   = false;
 int                Rogue_gc_threshold = ROGUE_GC_THRESHOLD_DEFAULT;
+int                Rogue_gc_count     = 0; // Purely informational
 bool               Rogue_gc_requested = false;
 RogueLogical       Rogue_configured = 0;
 int                Rogue_allocation_bytes_until_gc = Rogue_gc_threshold;
@@ -1324,6 +1325,7 @@ bool Rogue_collect_garbage( bool forced )
 
   if (Rogue_allocation_bytes_until_gc > 0 && !forced && !Rogue_gc_requested) return false;
   Rogue_gc_requested = false;
+  ++ Rogue_gc_count;
 
   Rogue_on_gc_begin.call();
 

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -167,6 +167,345 @@ pthread_mutex_t Rogue_thread_singleton_lock;
 //-----------------------------------------------------------------------------
 //  GC
 //-----------------------------------------------------------------------------
+#if ROGUE_GC_MODE_AUTO_MT
+// See the Rogue MT GC diagram for an explanation of some of this.
+
+#define ROGUE_GC_VAR static volatile int
+// (Curiously, volatile seems to help performance slightly.)
+
+#define ROGUE_MTGC_BARRIER asm volatile("" : : : "memory");
+
+// Atomic LL insertion
+#define ROGUE_LINKED_LIST_INSERT(__OLD,__NEW,__NEW_NEXT)            \
+  for(;;) {                                                         \
+    auto tmp = __OLD;                                               \
+    __NEW_NEXT = tmp;                                               \
+    if (__sync_bool_compare_and_swap(&(__OLD), tmp, __NEW)) break;  \
+  }
+
+// We assume malloc is safe, but the SOA needs safety if it's being used.
+#if ROGUEMM_SMALL_ALLOCATION_SIZE_LIMIT >= 0
+static pthread_mutex_t Rogue_mtgc_soa_mutex = PTHREAD_MUTEX_INITIALIZER;
+#define ROGUE_GC_SOA_LOCK    pthread_mutex_lock(&Rogue_mtgc_soa_mutex);
+#define ROGUE_GC_SOA_UNLOCK  pthread_mutex_unlock(&Rogue_mtgc_soa_mutex);
+#else
+#define ROGUE_GC_SOA_LOCK
+#define ROGUE_GC_SOA_UNLOCK
+#endif
+
+static inline void Rogue_collect_garbage_real ();
+void Rogue_collect_garbage_real_noinline ()
+{
+  Rogue_collect_garbage_real();
+}
+
+#if ROGUE_THREAD_MODE != ROGUE_THREAD_MODE_PTHREADS
+#error Currently, only --threads=pthreads is supported with --gc=auto-mt
+#endif
+
+// This is how unlikely() works in the Linux kernel
+#define ROGUE_UNLIKELY(_X) __builtin_expect(!!(_X), 0)
+
+#define ROGUE_GC_CHECK if (ROGUE_UNLIKELY(Rogue_mtgc_w)) Rogue_mtgc_W2_W3_W4(); // W1
+
+static pthread_mutex_t Rogue_mtgc_w_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t Rogue_mtgc_s_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t Rogue_mtgc_w_cond = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t Rogue_mtgc_s_cond = PTHREAD_COND_INITIALIZER;
+
+ROGUE_GC_VAR Rogue_mtgc_w = 0;
+ROGUE_GC_VAR Rogue_mtgc_s = 0;
+
+// Only one worker can be "running" (waiting for) the GC at a time.
+// To run, set r = 1, and wait for GC to set it to 0.  If r is already
+// 1, just wait.
+static pthread_mutex_t Rogue_mtgc_r_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t Rogue_mtgc_r_cond = PTHREAD_COND_INITIALIZER;
+ROGUE_GC_VAR Rogue_mtgc_r = 0;
+
+static pthread_mutex_t Rogue_mtgc_g_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t Rogue_mtgc_g_cond = PTHREAD_COND_INITIALIZER;
+ROGUE_GC_VAR Rogue_mtgc_g = 0; // Should GC
+
+static int Rogue_mtgc_should_quit = 0; // 0:normal 1:should-quit 2:has-quit
+
+static pthread_t Rogue_mtgc_thread;
+
+static void Rogue_mtgc_W2_W3_W4 (void);
+static inline void Rogue_mtgc_W3_W4 (void);
+
+inline void Rogue_mtgc_B1 ()
+{
+  pthread_mutex_lock(&Rogue_mtgc_s_mutex);
+  ++Rogue_mtgc_s;
+  pthread_cond_signal(&Rogue_mtgc_s_cond);
+  pthread_mutex_unlock(&Rogue_mtgc_s_mutex);
+}
+
+inline void Rogue_mtgc_B2_etc ()
+{
+  Rogue_mtgc_W3_W4();
+  // We can probably just do GC_CHECK here rather than this more expensive
+  // locking version.
+  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+  auto w = Rogue_mtgc_w;
+  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+  if (ROGUE_UNLIKELY(w)) Rogue_mtgc_W2_W3_W4(); // W1
+}
+
+static inline void Rogue_mtgc_W2 ()
+{
+  pthread_mutex_lock(&Rogue_mtgc_s_mutex);
+  ++Rogue_mtgc_s;
+  pthread_cond_signal(&Rogue_mtgc_s_cond);
+  pthread_mutex_unlock(&Rogue_mtgc_s_mutex);
+}
+
+static inline void Rogue_mtgc_W3_W4 ()
+{
+  // W3
+  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+  while (Rogue_mtgc_w != 0)
+  {
+    pthread_cond_wait(&Rogue_mtgc_w_cond, &Rogue_mtgc_w_mutex);
+  }
+  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+
+  // W4
+  pthread_mutex_lock(&Rogue_mtgc_s_mutex);
+  --Rogue_mtgc_s;
+  pthread_mutex_unlock(&Rogue_mtgc_s_mutex);
+}
+
+static void Rogue_mtgc_W2_W3_W4 ()
+{
+  Rogue_mtgc_W2();
+  Rogue_mtgc_W3_W4();
+}
+
+
+static thread_local int Rogue_mtgc_entered = 1;
+
+inline void Rogue_mtgc_enter()
+{
+  if (ROGUE_UNLIKELY(Rogue_mtgc_entered))
+#ifdef ROGUE_MTGC_DEBUG
+  {
+    printf("ALREADY ENTERED\n");
+    exit(1);
+  }
+#else
+  {
+    ++Rogue_mtgc_entered;
+    return;
+  }
+#endif
+
+  Rogue_mtgc_entered = 1;
+  Rogue_mtgc_B2_etc();
+}
+
+inline void Rogue_mtgc_exit()
+{
+  if (ROGUE_UNLIKELY(Rogue_mtgc_entered <= 0))
+  {
+    printf("Unabalanced Rogue enter/exit\n");
+    exit(1);
+  }
+
+  --Rogue_mtgc_entered;
+  Rogue_mtgc_B1();
+}
+
+static void Rogue_mtgc_M1_M2_GC_M3 (int quit)
+{
+  // M1
+  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+  Rogue_mtgc_w = 1;
+  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+
+  // M2
+  pthread_mutex_lock(&Rogue_mtgc_s_mutex);
+  while (Rogue_mtgc_s != Rogue_mt_tc)
+  {
+#if ROGUE_MTGC_DEBUG
+    if (Rogue_mtgc_s > Rogue_mt_tc || Rogue_mtgc_s < 0)
+    {
+      printf("INVALID VALUE OF S %i %i\n", Rogue_mtgc_s, Rogue_mt_tc);
+      exit(1);
+    }
+#endif
+
+    pthread_cond_wait(&Rogue_mtgc_s_cond, &Rogue_mtgc_s_mutex);
+  }
+  // We should actually be okay holding the S lock until the
+  // very end of the function if we want, and this would prevent
+  // threads that were blocking from ever leaving B2.  But
+  // We should be okay anyway, though S may temporarily != TC.
+  //pthread_mutex_unlock(&Rogue_mtgc_s_mutex);
+
+#if ROGUE_MTGC_DEBUG
+  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+  Rogue_mtgc_w = 2;
+  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+#endif
+
+  // GC
+  // Grab the SOA lock for symmetry.  It should actually never
+  // be held by another thread since they're all in GC sleep.
+  ROGUE_GC_SOA_LOCK;
+  Rogue_collect_garbage_real();
+
+  //NOTE: It's possible (Rogue_mtgc_s != Rogue_mt_tc) here, if we gave up the S
+  //      lock, though they should quickly go back to equality.
+
+  if (quit)
+  {
+    // Run a few more times to finish up
+    Rogue_collect_garbage_real_noinline();
+    Rogue_collect_garbage_real_noinline();
+
+    // Free from the SOA
+    RogueAllocator_free_all();
+  }
+  ROGUE_GC_SOA_UNLOCK;
+
+  // M3
+  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+  Rogue_mtgc_w = 0;
+  pthread_cond_broadcast(&Rogue_mtgc_w_cond);
+  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+  pthread_mutex_unlock(&Rogue_mtgc_s_mutex); // Could do much earlier
+}
+
+static void * Rogue_mtgc_threadproc (void *)
+{
+  int quit = 0;
+  while (quit == 0)
+  {
+    pthread_mutex_lock(&Rogue_mtgc_g_mutex);
+    while (!Rogue_mtgc_g && !Rogue_mtgc_should_quit)
+    {
+      pthread_cond_wait(&Rogue_mtgc_g_cond, &Rogue_mtgc_g_mutex);
+    }
+    Rogue_mtgc_g = 0;
+    quit = Rogue_mtgc_should_quit;
+    pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
+
+    pthread_mutex_lock(&Rogue_mt_thread_mutex);
+
+    Rogue_mtgc_M1_M2_GC_M3(quit);
+
+    pthread_mutex_unlock(&Rogue_mt_thread_mutex);
+
+    pthread_mutex_lock(&Rogue_mtgc_r_mutex);
+    Rogue_mtgc_r = 0;
+    pthread_cond_broadcast(&Rogue_mtgc_r_cond);
+    pthread_mutex_unlock(&Rogue_mtgc_r_mutex);
+  }
+
+  pthread_mutex_lock(&Rogue_mtgc_g_mutex);
+  Rogue_mtgc_should_quit = 2;
+  Rogue_mtgc_g = 0;
+  pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
+  return NULL;
+}
+
+// Cause GC to run and wait for a GC to complete.
+void Rogue_mtgc_run_gc_and_wait ()
+{
+  bool again;
+  do
+  {
+    again = false;
+    pthread_mutex_lock(&Rogue_mtgc_r_mutex);
+    if (Rogue_mtgc_r == 0)
+    {
+      Rogue_mtgc_r = 1;
+
+      // Signal GC to run
+      pthread_mutex_lock(&Rogue_mtgc_g_mutex);
+      Rogue_mtgc_g = 1;
+      pthread_cond_signal(&Rogue_mtgc_g_cond);
+      pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
+    }
+    else
+    {
+      // If one or more simultaneous requests to run the GC came in, run it
+      // again.
+      again = (Rogue_mtgc_r == 1);
+      ++Rogue_mtgc_r;
+    }
+    ROGUE_EXIT;
+    while (Rogue_mtgc_r != 0)
+    {
+      pthread_cond_wait(&Rogue_mtgc_r_cond, &Rogue_mtgc_r_mutex);
+    }
+    pthread_mutex_unlock(&Rogue_mtgc_r_mutex);
+    ROGUE_ENTER;
+  }
+  while (again);
+}
+
+static void Rogue_mtgc_quit_gc_thread ()
+{
+  //NOTE: This could probably be simplified (and the quit behavior removed
+  //      from Rogue_mtgc_M1_M2_GC_M3) since we now wait for all threads
+  //      to stop before calling this.
+  ROGUE_EXIT;
+  while (true)
+  {
+    pthread_mutex_lock(&Rogue_mtgc_g_mutex);
+    if (Rogue_mtgc_should_quit == 2)
+    {
+      pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
+      break;
+    }
+    Rogue_mtgc_g = 1;
+    Rogue_mtgc_should_quit = 1;
+    pthread_cond_signal(&Rogue_mtgc_g_cond);
+    pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
+    timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 1000000 * 10; // 10ms
+    nanosleep(&ts, NULL);
+  }
+  pthread_join(Rogue_mtgc_thread, NULL);
+  ROGUE_ENTER;
+}
+
+void Rogue_configure_gc()
+{
+  int c = pthread_create(&Rogue_mtgc_thread, NULL, Rogue_mtgc_threadproc, NULL);
+  if (c != 0)
+  {
+    exit(77); //TODO: Do something better in this (hopefully) rare case.
+  }
+}
+
+// Used as part of the ROGUE_BLOCKING_CALL macro.
+template<typename RT> RT Rogue_mtgc_reenter (RT expr)
+{
+  ROGUE_ENTER;
+  return expr;
+}
+
+#include <atomic>
+
+// We do all relaxed operations on this.  It's possible this will lead to
+// something "bad", but I don't think *too* bad.  Like an extra GC.
+// And I think that'll be rare, since the reset happens when all the
+// threads are synced.  But I could be wrong.  Should probably think
+// about this harder.
+std::atomic_int Rogue_allocation_bytes_until_gc(Rogue_gc_threshold);
+#define ROGUE_GC_COUNT_BYTES(__x) Rogue_allocation_bytes_until_gc.fetch_sub(__x, std::memory_order_relaxed);
+#define ROGUE_GC_AT_THRESHOLD (Rogue_allocation_bytes_until_gc.load(std::memory_order_relaxed) <= 0)
+#define ROGUE_GC_RESET_COUNT Rogue_allocation_bytes_until_gc.store(Rogue_gc_threshold, std::memory_order_relaxed);
+
+#else // Anything besides auto-mt
+
+#define ROGUE_GC_CHECK /* Does nothing in non-auto-mt modes */
+
 #define ROGUE_GC_SOA_LOCK
 #define ROGUE_GC_SOA_UNLOCK
 
@@ -175,7 +514,11 @@ int Rogue_allocation_bytes_until_gc = Rogue_gc_threshold;
 #define ROGUE_GC_AT_THRESHOLD (Rogue_allocation_bytes_until_gc <= 0)
 #define ROGUE_GC_RESET_COUNT Rogue_allocation_bytes_until_gc = Rogue_gc_threshold;
 
+
+#define ROGUE_MTGC_BARRIER
 #define ROGUE_LINKED_LIST_INSERT(__OLD,__NEW,__NEW_NEXT) do {__NEW_NEXT = __OLD; __OLD = __NEW;} while(false)
+
+#endif
 
 //-----------------------------------------------------------------------------
 //  RogueDebugTrace
@@ -882,6 +1225,18 @@ RogueAllocator* RogueAllocator_delete( RogueAllocator* THIS )
 void* RogueAllocator_allocate( RogueAllocator* THIS, int size )
 {
 #if ROGUE_GC_MODE_AUTO_MT
+#if ROGUE_MTGC_DEBUG
+    pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+    if (Rogue_mtgc_w == 2)
+    {
+      printf("ALLOC DURING GC!\n");
+      exit(1);
+    }
+    pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+#endif
+#endif
+
+#if ROGUE_GC_MODE_AUTO_ANY
   Rogue_collect_garbage();
 #endif
   if (size > ROGUEMM_SMALL_ALLOCATION_SIZE_LIMIT)
@@ -1056,6 +1411,8 @@ RogueObject* RogueAllocator_allocate_object( RogueAllocator* THIS, RogueType* of
 
   obj->type = of_type;
   obj->object_size = size;
+
+  ROGUE_MTGC_BARRIER; // Probably not necessary
 
   if (of_type->on_cleanup_fn)
   {
@@ -1454,6 +1811,8 @@ void Rogue_configure_gc()
   //GC_set_all_interior_pointers(0);
   GC_INIT();
 }
+#elif ROGUE_GC_MODE_AUTO_MT
+// Rogue_configure_gc already defined above.
 #else
 void Rogue_configure_gc()
 {
@@ -1479,7 +1838,11 @@ bool Rogue_collect_garbage( bool forced )
 {
   if (!forced && !Rogue_gc_requested & !ROGUE_GC_AT_THRESHOLD) return false;
 
+#if ROGUE_GC_MODE_AUTO_MT
+  Rogue_mtgc_run_gc_and_wait();
+#else
   Rogue_collect_garbage_real();
+#endif
 
   return true;
 }
@@ -1517,12 +1880,16 @@ void Rogue_quit()
 
   ROGUE_THREADS_WAIT_FOR_ALL;
 
+#if ROGUE_GC_MODE_AUTO_MT
+  Rogue_mtgc_quit_gc_thread();
+#else
   // Give a few GC's to allow objects requiring clean-up to do so.
   Rogue_collect_garbage( true );
   Rogue_collect_garbage( true );
   Rogue_collect_garbage( true );
 
   RogueAllocator_free_all();
+#endif
 
   for (i=0; i<Rogue_type_count; ++i)
   {

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -1052,6 +1052,15 @@ void* RogueAllocator_free( RogueAllocator* THIS, void* data, int size )
     ROGUE_GCDEBUG_STATEMENT(memset(data,0,size));
     if (size > ROGUEMM_SMALL_ALLOCATION_SIZE_LIMIT)
     {
+      // When debugging GC, it can be very useful to lock the object types of
+      // freed objects.  When valgrind points out access to freed memory, you
+      // can then see what it was.
+      #if 0
+      RogueObject* obj = (RogueObject*) data;
+      printf("DEL %i %p ", (int)pthread_self(), data);
+      RogueType_print_name( obj-> type );
+      printf("\n");
+      #endif
       ROGUE_DEL_BYTES( data );
     }
     else

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -1084,6 +1084,14 @@ void RogueAllocator_free_objects( RogueAllocator* THIS )
   THIS->objects = 0;
 }
 
+void RogueAllocator_free_all( )
+{
+  for (int i=0; i<Rogue_allocator_count; ++i)
+  {
+    RogueAllocator_free_objects( &Rogue_allocators[i] );
+  }
+}
+
 void RogueAllocator_collect_garbage( RogueAllocator* THIS )
 {
   // Global program objects have already been traced through.
@@ -1472,10 +1480,7 @@ void Rogue_quit()
   Rogue_collect_garbage( true );
   Rogue_collect_garbage( true );
 
-  for (i=0; i<Rogue_allocator_count; ++i)
-  {
-    RogueAllocator_free_objects( &Rogue_allocators[i] );
-  }
+  RogueAllocator_free_all();
 
   for (i=0; i<Rogue_type_count; ++i)
   {

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -666,6 +666,7 @@ void*        RogueAllocator_allocate( int size );
 RogueObject* RogueAllocator_allocate_object( RogueAllocator* THIS, RogueType* of_type, int size, int element_type_index=-1 );
 void*        RogueAllocator_free( RogueAllocator* THIS, void* data, int size );
 void         RogueAllocator_free_objects( RogueAllocator* THIS );
+void         RogueAllocator_free_all();
 void         RogueAllocator_collect_garbage( RogueAllocator* THIS );
 
 extern int                Rogue_allocator_count;

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -544,6 +544,11 @@ RogueString*   RogueString_validate( RogueString* THIS );
 //-----------------------------------------------------------------------------
 //  RogueArray
 //-----------------------------------------------------------------------------
+#if defined(__clang__)
+#define ROGUE_EMPTY_ARRAY
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define ROGUE_EMPTY_ARRAY 0
+#endif
 struct RogueArray : RogueObject
 {
   int  count;
@@ -565,14 +570,14 @@ struct RogueArray : RogueObject
 #else
   union
   {
-    RogueObject*   as_objects[];
-    RogueByte      as_logicals[];
-    RogueByte      as_bytes[];
-    RogueCharacter as_characters[];
-    RogueInt32     as_int32s[];
-    RogueInt64     as_int64s[];
-    RogueReal32    as_real32s[];
-    RogueReal64    as_real64s[];
+    RogueObject*   as_objects[ROGUE_EMPTY_ARRAY];
+    RogueByte      as_logicals[ROGUE_EMPTY_ARRAY];
+    RogueByte      as_bytes[ROGUE_EMPTY_ARRAY];
+    RogueCharacter as_characters[ROGUE_EMPTY_ARRAY];
+    RogueInt32     as_int32s[ROGUE_EMPTY_ARRAY];
+    RogueInt64     as_int64s[ROGUE_EMPTY_ARRAY];
+    RogueReal32    as_real32s[ROGUE_EMPTY_ARRAY];
+    RogueReal64    as_real64s[ROGUE_EMPTY_ARRAY];
   };
 #endif
 };

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -681,7 +681,6 @@ extern RogueString*       Rogue_literal_strings[];
 extern RogueLogical       Rogue_configured;
 extern int                Rogue_argc;
 extern const char**       Rogue_argv;
-extern int                Rogue_allocation_bytes_until_gc;
 extern bool               Rogue_gc_logging;
 extern int                Rogue_gc_threshold;
 extern bool               Rogue_gc_requested;

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -279,6 +279,7 @@ T rogue_ptr (T p)
 #if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
 
 #include <pthread.h>
+#include <atomic>
 
 #define ROGUE_THREAD_LOCAL thread_local
 
@@ -446,7 +447,11 @@ struct RogueType
   const int*   property_type_indices;
   const int*   property_offsets;
 
+#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
+  std::atomic<RogueObject*> _singleton;
+#else
   RogueObject* _singleton;
+#endif
   const void** methods; // first function pointer in Rogue_dynamic_method_table
   int          method_count;
 

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -89,6 +89,10 @@ extern void Rogue_configure_gc();
 
 #if ROGUE_GC_MODE_BOEHM
   #define GC_NAME_CONFLICT
+  #if ROGUE_THREAD_MODE
+    // Assume GC built for the right thread mode!
+    #define GC_THREADS 1
+  #endif
   #include "gc.h"
   #include "gc_cpp.h"
   #include "gc_allocator.h"

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -67,12 +67,35 @@
 // ROGUE_EXITed before the first event handler.  If you're using the FAST
 // variants and don't do this, things will likely go quite badly for you.
 
+#if ROGUE_GC_MODE_AUTO_MT
+
+#define ROGUE_ENTER Rogue_mtgc_enter()
+#define ROGUE_EXIT  Rogue_mtgc_exit()
+
+#define ROGUE_ENTER_FAST Rogue_mtgc_B2_etc()
+#define ROGUE_EXIT_FAST  Rogue_mtgc_B1()
+
+inline void Rogue_mtgc_B1 (void);
+inline void Rogue_mtgc_B2_etc (void);
+inline void Rogue_mtgc_enter (void);
+inline void Rogue_mtgc_exit (void);
+
+template<typename RT> RT Rogue_mtgc_reenter (RT expr);
+
+#define ROGUE_BLOCKING_CALL(__x) (ROGUE_EXIT, Rogue_mtgc_reenter((__x)))
+#define ROGUE_BLOCKING_VOID_CALL(__x) do {ROGUE_EXIT; __x; ROGUE_ENTER;}while(false)
+
+#else
+
 #define ROGUE_ENTER
 #define ROGUE_EXIT
 #define ROGUE_ENTER_FAST
 #define ROGUE_EXIT_FAST
 
 #define ROGUE_BLOCKING_CALL(__x) __x
+
+#endif
+
 #define ROGUE_BLOCKING_ENTER ROGUE_EXIT
 #define ROGUE_BLOCKING_EXIT  ROGUE_ENTER
 
@@ -650,6 +673,7 @@ RogueArray* RogueArray_set( RogueArray* THIS, RogueInt32 i1, RogueArray* other, 
 
 // Small allocation limit is 256 bytes - afterwards objects are allocated
 // from the system.
+// Set to -1 to disable the small object allocator.
 #ifndef ROGUEMM_SMALL_ALLOCATION_SIZE_LIMIT
 #  define ROGUEMM_SMALL_ALLOCATION_SIZE_LIMIT  ((ROGUEMM_SLOT_COUNT-1) << ROGUEMM_GRANULARITY_BITS)
 #endif

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -51,6 +51,32 @@
 #endif
 
 //-----------------------------------------------------------------------------
+//  Multithreading
+//-----------------------------------------------------------------------------
+// When exiting Rogue code for a nontrivial amount of time (e.g., making a
+// blocking call or returning from a native event handler), put a
+// ROGUE_EXIT in your code.  When re-entering (e.g., after the blocking call
+// or on entering a native event handler which is going to call Rogue code),
+// do ROGUE_ENTER.
+// ROGUE_BLOCKING_ENTER/EXIT do the same things but with the meanings reversed
+// in case this makes it easier to think about.  An even easier way to make
+// a blocking call is to simply wrap it in ROGUE_BLOCKING_CALL(foo(...)).
+// The FAST variants are faster, but you need to be careful that they are
+// exactly balanced.
+// Of special note is that in the event handler case, you should have
+// ROGUE_EXITed before the first event handler.  If you're using the FAST
+// variants and don't do this, things will likely go quite badly for you.
+
+#define ROGUE_ENTER
+#define ROGUE_EXIT
+#define ROGUE_ENTER_FAST
+#define ROGUE_EXIT_FAST
+
+#define ROGUE_BLOCKING_CALL(__x) __x
+#define ROGUE_BLOCKING_ENTER ROGUE_EXIT
+#define ROGUE_BLOCKING_EXIT  ROGUE_ENTER
+
+//-----------------------------------------------------------------------------
 //  Garbage Collection
 //-----------------------------------------------------------------------------
 #define ROGUE_DEF_LOCAL_REF(_t_,_n_, _v_) _t_ _n_ = _v_

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -146,7 +146,7 @@ extern void Rogue_configure_gc();
   #define ROGUE_XDECREF(_o_) Rogue_Boehm_DecRef(_o_)
 #endif
 
-#if ROGUE_GC_MODE_AUTO
+#if ROGUE_GC_MODE_AUTO_ANY
   #undef ROGUE_DEF_LOCAL_REF_NULL
   #define ROGUE_DEF_LOCAL_REF_NULL(_t_,_n_) RoguePtr<_t_> _n_;
   #undef ROGUE_DEF_LOCAL_REF

--- a/Source/Libraries/Standard/Random.rogue
+++ b/Source/Libraries/Standard/Random.rogue
@@ -76,7 +76,7 @@ class Random [singleton]
       # the range (low,high) exclusive (does not include low or high).
       return (real64 * (high-low)) + low
 
-    method int64->Int32
+    method int64->Int64
       # Returns a normalized, evenly distributed random integer in
       # the range [0,2^63-1] inclusive.
       local result = int32->Int64 :<<: 32

--- a/Source/Libraries/Standard/Runtime.rogue
+++ b/Source/Libraries/Standard/Runtime.rogue
@@ -18,6 +18,19 @@ class Runtime [essential]
       native "$n = Rogue_gc_threshold;"
       return n
 
+    method gc_count->Int
+      # Return the number of times the GC has run.
+      # Note that this may wrap!
+      local r : Int
+      native @|#if ROGUE_GC_MODE_BOEHM
+              |  GC_prof_stats_s stats = {0};
+              |  GC_get_prof_stats(&stats, sizeof(stats));
+              |  $r = stats.gc_no;
+              |#else
+              |  $r = Rogue_gc_count;
+              |#endif
+      return r
+
     method literal_string( string_index:Int32 )->String
       if (string_index < 0 or string_index >= literal_string_count) return null
       return native("Rogue_literal_strings[$string_index]")->String

--- a/Source/Libraries/Standard/System.rogue
+++ b/Source/Libraries/Standard/System.rogue
@@ -55,13 +55,16 @@ class System [essential]
 
     method sleep( seconds:Real64 )
       # Suspends execution of this program for the specified number of seconds.
+      local do_exit = seconds > 0.5 # Or should it be lower?
       local nanoseconds = Int32( seconds.fractional_part * 1000000000.0 )
       seconds = seconds.whole_part
 
       native @|timespec sleep_time;
               |sleep_time.tv_sec = (time_t) $seconds;
               |sleep_time.tv_nsec = (long) $nanoseconds;
+              |if ($do_exit) ROGUE_EXIT;
               |nanosleep( &sleep_time, NULL );
+              |if ($do_exit) ROGUE_ENTER;
 
     method sync_storage
       noAction

--- a/Source/Libraries/Standard/System.rogue
+++ b/Source/Libraries/Standard/System.rogue
@@ -12,7 +12,7 @@ class System [essential]
     environment            : SystemEnvironment
 
   GLOBAL METHODS
-    method exit( result_code:Int32 )
+    method exit( result_code=0:Int32 )
       $if ("C++")
         native @|Rogue_quit();
                 |exit( $result_code );

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -142,7 +142,7 @@ nativeCode
 
 inline void roguethread_simple_spin_lock(int *p)
 {
-    while(!__sync_bool_compare_and_swap(p, 0, 1));
+    while(!__sync_bool_compare_and_swap(p, 0, 1)) {};
 }
 
 inline void roguethread_simple_spin_unlock(int volatile *p)

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -142,7 +142,9 @@ nativeCode
 
 inline void roguethread_simple_spin_lock(int *p)
 {
+    ROGUE_EXIT;
     while(!__sync_bool_compare_and_swap(p, 0, 1)) {};
+    ROGUE_ENTER;
 }
 
 inline void roguethread_simple_spin_unlock(int volatile *p)
@@ -191,7 +193,9 @@ $endIf
 class Thread (id:Int64) [compound]
   METHODS
     method join ()
-      native @|pthread_join((pthread_t)$this.id, NULL);
+      native @|ROGUE_EXIT;
+              |pthread_join((pthread_t)$this.id, NULL);
+              |ROGUE_ENTER;
 
     method detach ()
       native @|pthread_detach((pthread_t)$this.id);
@@ -284,7 +288,7 @@ class FastBarrier [compound]
     method destroy [macro]
       native "pthread_barrier_destroy(&$this._barrier);"
     method wait -> Logical [macro]
-      native("(RogueInt32)(pthread_barrier_wait(&$this._barrier) == PTHREAD_BARRIER_SERIAL_THREAD)")
+      native("ROGUE_BLOCKING_CALL((RogueInt32)(pthread_barrier_wait(&$this._barrier) == PTHREAD_BARRIER_SERIAL_THREAD))")
 endClass
 
 
@@ -297,7 +301,7 @@ class Barrier
     method destroy
       native "pthread_barrier_destroy(&$this->_barrier);"
     method wait -> Logical [macro]
-      native("(RogueInt32)(pthread_barrier_wait(&$this->_barrier) == PTHREAD_BARRIER_SERIAL_THREAD)")
+      native("ROGUE_BLOCKING_CALL((RogueInt32)(pthread_barrier_wait(&$this->_barrier) == PTHREAD_BARRIER_SERIAL_THREAD))")
 endClass
 
 
@@ -317,7 +321,7 @@ class Mutex
       return this
 
     method lock [macro]
-      native "pthread_mutex_lock(&$this->_lock);"
+      native "ROGUE_BLOCKING_CALL(pthread_mutex_lock(&$this->_lock));"
 
     method on_end_use
       unlock
@@ -343,7 +347,7 @@ class SpinLock
       return this
 
     method lock [macro]
-      native "pthread_spin_lock(&$this->_lock);"
+      native "ROGUE_BLOCKING_CALL(pthread_spin_lock(&$this->_lock));"
 
     method on_end_use
       unlock
@@ -407,13 +411,13 @@ class Semaphore
 
     method acquire
       local r : Int64
-      native "$r = RogueSemaphore_wait(&$this->_sem);"
+      native "$r = ROGUE_BLOCKING_CALL(RogueSemaphore_wait(&$this->_sem));"
       require(r == 0)
 
     method try_acquire -> Logical
       # Returns true if you got it
       local r : Int64
-      native "$r = RogueSemaphore_try_wait(&$this->_sem);"
+      native "$r = ROGUE_BLOCKING_CALL(RogueSemaphore_try_wait(&$this->_sem));"
       return r == 0
 
     method release

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -4,7 +4,7 @@
 
 nativeHeader
 
-//#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
+#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
 
 // #include "gc.h" - included elsewhere
 #include <pthread.h>
@@ -133,7 +133,7 @@ pthread_t roguethread_create ( std::function<void()> f )
   return r;
 }
 
-//#endif
+#endif
 
 endNativeHeader
 

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -293,6 +293,8 @@ class FastBarrier [compound]
       native "pthread_barrier_destroy(&$this._barrier);"
     method wait -> Logical [macro]
       native("ROGUE_BLOCKING_CALL((RogueInt32)(pthread_barrier_wait(&$this._barrier) == PTHREAD_BARRIER_SERIAL_THREAD))")
+    method operator== (other:FastBarrier) -> Logical
+      return false # Not comparable
 endClass
 
 
@@ -378,6 +380,9 @@ class SimpleSpinLock [compound]
 
     method unlock [macro]
       native "roguethread_simple_spin_unlock(&$this._lock);"
+
+    method operator== (other:SimpleSpinLock) -> Logical
+      return native("$this._lock == $other._lock")->Logical
 endClass
 
 

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -57,12 +57,13 @@ RogueSemaphore_wait( struct RogueSemaphore *s )
 #endif
 }
 
-static inline void
+// Returns true if semaphore was decremented.
+static inline bool
 RogueSemaphore_try_wait( struct RogueSemaphore *s )
 {
 
 #ifdef __APPLE__
-    dispatch_semaphore_wait(s->sem, DISPATCH_TIME_NOW);
+    return dispatch_semaphore_wait(s->sem, DISPATCH_TIME_NOW) == 0;
 #else
     int r;
 
@@ -70,6 +71,9 @@ RogueSemaphore_try_wait( struct RogueSemaphore *s )
     {
       r = sem_trywait(&s->sem);
     } while (r == -1 && errno == EINTR);
+
+    if (r == -1) return false;
+    return true;
 #endif
 }
 
@@ -410,9 +414,7 @@ class Semaphore
       native "RogueSemaphore_destroy(&$this->_sem);"
 
     method acquire
-      local r : Int64
-      native "$r = ROGUE_BLOCKING_CALL(RogueSemaphore_wait(&$this->_sem));"
-      require(r == 0)
+      native "ROGUE_BLOCKING_VOID_CALL(RogueSemaphore_wait(&$this->_sem));"
 
     method try_acquire -> Logical
       # Returns true if you got it
@@ -421,9 +423,7 @@ class Semaphore
       return r == 0
 
     method release
-      local r : Int64
-      native "$r = RogueSemaphore_post(&$this->_sem);"
-      require(r == 0)
+      native "RogueSemaphore_post(&$this->_sem);"
 
     method release (n : Int32)
       forEach (_ in 1..n)

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -154,6 +154,7 @@ inline void roguethread_simple_spin_unlock(int volatile *p)
 
 #define ROGUE_THREAD_LAMBDA_START \
   std::function<void()> f = [=] () {                                                              \
+    Rogue_thread_register();                                                                      \
     Rogue_init_thread();                                                                          \
     ROGUE_THREAD_DEBUG_STATEMENT(RogueDebugTrace __trace( "Thread.lambda()", "thread.rogue", 1)); \
     try                                                                                           \
@@ -166,6 +167,7 @@ inline void roguethread_simple_spin_unlock(int volatile *p)
       RogueException__display( err );                                                             \
     }                                                                                             \
     Rogue_deinit_thread();                                                                        \
+    Rogue_thread_unregister();                                                                    \
   };
 
 endNativeCode

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -151,15 +151,15 @@ inline void roguethread_simple_spin_unlock(int volatile *p)
     *p = 0;
 }
 
-
-#define ROGUE_THREAD_LAMBDA_START \
+#define ROGUE_THREAD_LAMBDA_START(__f) \
+  RogueObject_retain(__f);                                                                        \
   std::function<void()> f = [=] () {                                                              \
     Rogue_thread_register();                                                                      \
     Rogue_init_thread();                                                                          \
     ROGUE_THREAD_DEBUG_STATEMENT(RogueDebugTrace __trace( "Thread.lambda()", "thread.rogue", 1)); \
     try                                                                                           \
     {
-#define ROGUE_THREAD_LAMBDA_END \
+#define ROGUE_THREAD_LAMBDA_END(__f) \
     }                                                                                             \
     catch (RogueException* err)                                                                   \
     {                                                                                             \
@@ -167,6 +167,7 @@ inline void roguethread_simple_spin_unlock(int volatile *p)
       RogueException__display( err );                                                             \
     }                                                                                             \
     Rogue_deinit_thread();                                                                        \
+    RogueObject_release(__f);                                                                     \
     Rogue_thread_unregister();                                                                    \
   };
 
@@ -213,35 +214,36 @@ class Thread (id:Int64) [compound]
       return ok
 
   GLOBAL METHODS
+
     method create (f:Function()) -> Thread
       local r : Int64
-      native @|ROGUE_THREAD_LAMBDA_START
+      native @|ROGUE_THREAD_LAMBDA_START($f)
       f()
-      native @|ROGUE_THREAD_LAMBDA_END
+      native @|ROGUE_THREAD_LAMBDA_END($f)
               |$r = (RogueInt64)roguethread_create(f);
       return Thread(r)
 
     method create <<$T1>> (f:Function($T1), a1:$T1) -> Thread
       local r : Int64
-      native @|ROGUE_THREAD_LAMBDA_START
+      native @|ROGUE_THREAD_LAMBDA_START($f)
         f(a1)
-      native @|ROGUE_THREAD_LAMBDA_END
+      native @|ROGUE_THREAD_LAMBDA_END($f)
               |$r = (RogueInt64)roguethread_create(f);
       return Thread(r)
 
     method create <<$T1,$T2>> (f:Function($T1,$T2), a1:$T1, a2:$T2) -> Thread
       local r : Int64
-      native @|ROGUE_THREAD_LAMBDA_START
+      native @|ROGUE_THREAD_LAMBDA_START($f)
         f(a1,a2)
-      native @|ROGUE_THREAD_LAMBDA_END
+      native @|ROGUE_THREAD_LAMBDA_END($f)
               |$r = (RogueInt64)roguethread_create(f);
       return Thread(r)
 
     method create <<$T1,$T2,$T3>> (f:Function($T1,$T2,$T3), a1:$T1, a2:$T2, a3:$T3) -> Thread
       local r : Int64
-      native @|ROGUE_THREAD_LAMBDA_START
+      native @|ROGUE_THREAD_LAMBDA_START($f)
         f(a1,a2,a3)
-      native @|ROGUE_THREAD_LAMBDA_END
+      native @|ROGUE_THREAD_LAMBDA_END($f)
               |$r = (RogueInt64)roguethread_create(f);
       return Thread(r)
 

--- a/Source/Libraries/Standard/WebSocket.rogue
+++ b/Source/Libraries/Standard/WebSocket.rogue
@@ -1,12 +1,4 @@
-class WebSocket
-  GLOBAL METHODS
-    method create( url:String, port=null:Int32?, protocols=null:String[] )->WebSocket
-$if ("Console")
-      return LWSWebSocket( url, port, protocols )
-$else
-      return WebSocket().init( url, port, protocols )
-$endIf
-
+class WebSocketBase
   PROPERTIES
     url       : String
     port      : Int32?
@@ -14,11 +6,15 @@ $endIf
 
   METHODS
     method init( url, port, protocols )
+      _init()
+
+    method _init()
       println "WebSocket is not supported on $." (System.os)
 endClass
 
 
-class LWSWebSocket : WebSocket
+$if ("Console")
+class WebSocket : WebSocketBase
   DEPENDENCIES
     nativeHeader #include "libwebsockets.h"
     #$compileArg "-L"
@@ -36,7 +32,7 @@ class LWSWebSocket : WebSocket
     native "lws_protocols* protocols;"
 
   METHODS
-    method init( url, port, protocols )
+    method _init()
       native @|lws_context_creation_info info;
               |memset( &info, 0, sizeof(info) );
               |info.gid = -1;
@@ -73,7 +69,10 @@ class LWSWebSocket : WebSocket
               |}
 
 endClass
-
+$else
+class WebSocket : WebSocketBase
+endClass
+$endIf
 
 class WebSocketHandler
 endClass

--- a/Source/RogueC/Attributes.rogue
+++ b/Source/RogueC/Attributes.rogue
@@ -74,6 +74,9 @@ class Attributes
       endIf
       return this
 
+    method includes( flag:Int32 )->Logical
+      return (flags & flag) == flag
+
     method element_type_name->String
       which (flags & Attribute.type_mask)
         case Attribute.is_primitive: return "primitive"

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -2049,17 +2049,27 @@ augment Type
           writer.print( this ).print( "() { memset( this, 0, sizeof(" ).print( this ).println( ") ); }" )
           writer.println
 
+          local native_property_count = 0
+          forEach (p in property_list)
+            if (p.is_native) ++native_property_count
+          endForEach
+
+          # This is sort of a strange place to do this, but we usually need to
+          # count the native properties here anyway.
+          local compare_method = find_method("operator==($)" (this.name))
+          if (compare_method is null or (compare_method.attributes.includes(Attribute.is_generated)))
+            if (native_property_count != 0)
+              throw t.error( "Compound $ contains native properties and must therefore implement operator==()" (name) )
+            endIf
+          endIf
+
           if (is_optional)
             # Value Constructor, exists->true
             writer.print( this ).print( "( " ).print( property_list.first.type )
             writer.println( " value, bool exists=true ) : value(value), exists(exists) {}" )
           else
             # Standard Constructor
-            local native_property_count = 0
             contingent
-              forEach (p in property_list)
-                if (p.is_native) ++native_property_count
-              endForEach
               necessary (native_property_count == 0)
 
             satisfied

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -747,7 +747,10 @@ augment Program
         writer.println @|  if (type->type_info) RogueTypeInfo_trace( type->type_info );
       endIf
 
-      writer.println @|  if (type->_singleton) type->trace_fn( type->_singleton );
+      writer.println @|  {
+                      |    auto singleton = ROGUE_GET_SINGLETON(type);
+                      |    if (singleton) type->trace_fn( singleton );
+                      |  }
                       |}
 
 
@@ -1146,7 +1149,7 @@ augment Program
 
 
       # Call Global.on_launch()
-      writer.println @|RogueGlobal__on_launch( (RogueClassGlobal*) (RogueType_singleton(RogueTypeGlobal)) );
+      writer.println @|RogueGlobal__on_launch( (RogueClassGlobal*) (ROGUE_SINGLETON(Global)) );
                       |Rogue_collect_garbage();
 
       writer.indent -= 2
@@ -2939,11 +2942,11 @@ augment CmdWriteSingleton
       if (not of_type.is_singleton)
         throw t.error( "$ is not a singleton." (of_type.name) )
       endIf
-      writer.print( "RogueType" ).print( of_type.cpp_name ).print( "->_singleton = " )
+      writer.print( "ROGUE_SET_SINGLETON(RogueType" ).print( of_type.cpp_name ).print( ", " )
       if (new_value.type is not of_type) writer.print_cast( new_value.type, of_type )
       writer.print( "(" )
       new_value.write_cpp( writer )
-      writer.println( ");" )
+      writer.println( "));" )
 endAugment
 
 augment CmdReadLocal

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -3817,3 +3817,17 @@ augment CmdIntrospectionCall
       writer.print( "))" )
 endAugment
 
+augment CmdSourceComment
+  METHODS
+    method write_cpp( writer:CPPWriter, is_statement=false:Logical )
+      local c = comment
+      local newline = false
+      if (c.ends_with("\n"))
+        c = c.before(c.count - 1)
+        newline = true
+      endIf
+      writer.print "/* " + comment + " */"
+      if (newline)
+        writer.println
+      endIf
+endAugment

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -1033,6 +1033,7 @@ augment Program
                       |Rogue_argc = argc;
                       |Rogue_argv = argv;
                       |
+                      |Rogue_thread_register();
                       |Rogue_configure_gc();
                       |Rogue_configure_types();
                       |set_terminate( Rogue_terminate_handler );

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -1929,7 +1929,7 @@ augment RogueC
                   |  $compiler_name = RogueString_create_from_utf8( "g++ -Wall -std=gnu++11 -fno-strict-aliasing -Wno-invalid-offsetof" );
                   |#endif
           if (RogueC.thread_mode == ThreadMode.PTHREADS)
-            compiler_name += " -pthreads"
+            compiler_name += " -pthread"
           endIf
         endIf
 

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -2327,6 +2327,9 @@ augment Method
           writer.print("ROGUE_DEF_LOCAL_REF(").print(param.type).print(",").print(param.cpp_name).print(",").print(param.parameter_cpp_name).println(");")
         endIf
       endForEach
+
+      writer.println "ROGUE_GC_CHECK;"
+
       if (type_context.is_aspect and not is_global)
         writer.println( "switch (THIS->type->index)" );
         writer.println "{"
@@ -2692,6 +2695,7 @@ augment CmdGenericLoop
       endIf
       writer.println( "{" )
       writer.indent += 2
+      writer.println( "ROGUE_GC_CHECK;" )
       statements.write_cpp( writer )
       writer.indent -= 2
       writer.println( "}" )

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -196,8 +196,16 @@ augment Program
       # It'd be nice to be able to override these with a C++ -D arg...
       writer.print "#define ROGUE_GC_MODE_MANUAL "
       writer.println select{RogueC.gc_mode == GCMode.MANUAL: "1" || "0"}
-      writer.print "#define ROGUE_GC_MODE_AUTO "
-      writer.println select{RogueC.gc_mode == GCMode.AUTO: "1" || "0"}
+      writer.print "#define ROGUE_GC_MODE_AUTO_ST "
+      writer.println select{RogueC.gc_mode == GCMode.AUTO_ST: "1" || "0"}
+      writer.print "#define ROGUE_GC_MODE_AUTO_MT "
+      writer.println select{RogueC.gc_mode == GCMode.AUTO_MT: "1" || "0"}
+      writer.print "#define ROGUE_GC_MODE_AUTO_ANY "
+      if (RogueC.gc_mode == GCMode.AUTO_ST or RogueC.gc_mode == GCMode.AUTO_MT)
+        writer.println "1"
+      else
+        writer.println "0"
+      endIf
       writer.print "#define ROGUE_GC_MODE_BOEHM "
       writer.println select{RogueC.gc_mode == GCMode.BOEHM: "1" || "0"}
       writer.print "#define ROGUE_GC_MODE_BOEHM_TYPED "
@@ -1778,7 +1786,7 @@ class CPPWriter
         elseIf (arg instanceOf CmdReadArrayElement)
           # It's possible to shoot oneself in the foot with this, but it's
           # potentially useful, so we allow it when it's easy.
-          if (RogueC.gc_mode == GCMode.AUTO)
+          if (RogueC.gc_mode == GCMode.AUTO_ST or RogueC.gc_mode == GCMode.AUTO_MT)
             if (param_info)
               throw arg.t.error("The argument for parameter '$' cannot be aliased, because element access aliases " ...
                                 "are not currently supported in the active garbage collection mode." (param_info.name))
@@ -1794,7 +1802,7 @@ class CPPWriter
             throw arg.t.error("Cannot call a [mutating] method on a context produced by evaluating an expression - mutating methods can only be called only local variable and singleton contexts.")
           endIf
         endIf
-        if (RogueC.gc_mode == GCMode.AUTO)
+        if (RogueC.gc_mode == GCMode.AUTO_ST or RogueC.gc_mode == GCMode.AUTO_MT)
           if (not (param_type.is_primitive or param_type.is_compound))
             if (param_info)
               throw arg.t.error("The parameter '$' can not be an alias, because the active garbage collection mode " ...
@@ -2428,7 +2436,11 @@ augment Local
       return _parameter_cpp_name
 
     method parameter_needs_gc->Logical
-      return is_modified and type.is_reference and RogueC.gc_mode == GCMode.AUTO
+      if (is_modified and type.is_reference)
+        if (RogueC.gc_mode == GCMode.AUTO_ST) return true
+        if (RogueC.gc_mode == GCMode.AUTO_MT) return true
+      endIf
+      return false
 endAugment
 
 #------------------------------------------------------------------------------

--- a/Source/RogueC/Cmd.rogue
+++ b/Source/RogueC/Cmd.rogue
@@ -6032,3 +6032,16 @@ class CmdIntrospectionCall( t, handler:IntrospectionCallHandler, args:CmdArgs ) 
       return handler.return_type
 endClass
 
+
+class CmdSourceComment( t, comment:String ) : Cmd
+  METHODS
+    method cloned( clone_args:CloneArgs, new_t=null:Token )->CmdSourceComment
+      if (new_t) t = new_t
+      return CmdSourceComment( t, comment )
+
+    method resolve( scope:Scope )->Cmd
+      return this
+
+    method to->String
+      return "CmdSourceComment:$" (comment)
+endClass

--- a/Source/RogueC/Parser.rogue
+++ b/Source/RogueC/Parser.rogue
@@ -2128,6 +2128,8 @@ class Parser
       local cmd_if = CmdIf( t )
       cmd_if.condition = parse_expression
 
+      consume(TokenType.keyword_then)
+
       if (consume_eols)
         # multi-line if
         parse_multi_line_statements( cmd_if.statements )
@@ -2206,6 +2208,16 @@ class Parser
       local t = read  # 'loop'
       local cmd_loop = CmdGenericLoop( t, CmdControlStructure.type_loop, null )
 
+      if (consume(TokenType.keyword_do))
+        if (consume_eols)
+          parse_multi_line_statements( cmd_loop.statements )
+          must_consume( TokenType.keyword_endLoop )
+        else
+          parse_single_line_statements( cmd_loop.statements )
+        endIf
+        return cmd_loop
+      endIf
+
       if (not consume_eols)
         # loop N
         #   ...
@@ -2224,6 +2236,7 @@ class Parser
         cmd_loop.add_control_var( last_var )
         cmd_loop.add_upkeep( step_cmd )
 
+        consume(TokenType.keyword_do)
         if (not consume_eols)
           parse_single_line_statements( cmd_loop.statements )
           return cmd_loop
@@ -2248,6 +2261,8 @@ class Parser
     method parse_while->CmdGenericLoop
       local t = read
       local cmd_while = CmdGenericLoop( t, CmdControlStructure.type_while, parse_expression )
+
+      consume(TokenType.keyword_do)
 
       if (consume_eols)
         # multi-line while
@@ -2305,6 +2320,7 @@ class Parser
               local cmd_for_each = create_generic_loop_from_range( t, access.name, range )
 
               if (has_parens) must_consume( TokenType.symbol_close_paren )
+              consume(TokenType.keyword_do)
               parse_single_or_multi_line_statements( cmd_for_each.statements, TokenType.keyword_endForEach )
 
               return cmd_for_each
@@ -2329,6 +2345,7 @@ class Parser
               endIf
 
               if (has_parens) must_consume( TokenType.symbol_close_paren )
+              consume(TokenType.keyword_do)
 
               local cmd_for_each : CmdForEach
               if (access)
@@ -2382,6 +2399,7 @@ class Parser
               endIf
 
               if (has_parens) must_consume( TokenType.symbol_close_paren )
+              consume(TokenType.keyword_do)
 
               local cmd_for_each = CmdForEach( t, null as String, access.name, collection, step_cmd )
               cmd_for_each.first_cmd = first_cmd
@@ -2402,6 +2420,7 @@ class Parser
         if (range)
           local cmd_for_each = create_generic_loop_from_range( t, Program.create_unique_id, range )
           if (has_parens) must_consume( TokenType.symbol_close_paren )
+          consume(TokenType.keyword_do)
           parse_single_or_multi_line_statements( cmd_for_each.statements, TokenType.keyword_endForEach )
 
           return cmd_for_each

--- a/Source/RogueC/RogueC.rogue
+++ b/Source/RogueC/RogueC.rogue
@@ -37,7 +37,8 @@ RogueC.launch
 class GCMode
   ENUMERATE
     MANUAL
-    AUTO
+    AUTO_ST
+    AUTO_MT
     BOEHM
     BOEHM_TYPED
 endClass
@@ -106,7 +107,7 @@ class RogueC [singleton]
     scanners_by_filepath = Table<<String,Scanner>>()
     stopwatch : Stopwatch
 
-    gc_mode = GCMode.AUTO    : Int32
+    gc_mode = GCMode.AUTO_ST : Int32
     gc_threshold = 1024*1024 : Int32
 
     thread_mode = ThreadMode.NONE : Int32
@@ -207,10 +208,12 @@ class RogueC [singleton]
                    |    Use command line directives to compile and run the output of the
                    |    compiled .rogue program.  Automatically enables the --main option.
                    |
-                   |  --gc[=auto|manual|boehm|boehm-typed]
+                   |  --gc[=auto|auto-mt|manual|boehm|boehm-typed]
                    |    Set the garbage collection mode:
                    |      --gc=auto        - Rogue collects garbage as it executes.  Slower than
                    |                         'manual' without optimizations enabled.
+                   |      --gc=auto-mt     - Like auto, but works with multithreading (i.e., when
+                   |                         the --threads option is not 'none').
                    |      --gc=manual      - Rogue_collect_garbage() must be manually called
                    |                         in-between calls into the Rogue runtime.
                    |      --gc=boehm       - Uses the Boehm garbage collector.  The Boehm's GC
@@ -258,8 +261,10 @@ class RogueC [singleton]
                     |    Enables --debug automatically.
                     |
                     |  --threads=[none|pthreads]
-                    |    Set the threading mode:
-                    |      --threads=none     - No multithreading support.
+                    |    Set the threading mode.  Note that if you enable multithreading, you
+                    |    likely want to adjust the --gc mode also (e.g., to auto-mt or boehm).
+                    |    The threading mode may be one of:
+                    |      --threads=none     - No multithreading support. (Default)
                     |      --threads=pthreads - Multithreading based on pthreads.
                     |
                     |  --todo[="KEYWORD"]
@@ -628,7 +633,9 @@ $endIf
             case "--gc"
               if ((not value.count) or value == "auto")
                 # Default to AUTO if nothing specified
-                gc_mode = GCMode.AUTO
+                gc_mode = GCMode.AUTO_ST
+              elseIf (value == "auto-mt")
+                gc_mode = GCMode.AUTO_MT
               elseIf (value == "manual")
                 gc_mode = GCMode.MANUAL
               elseIf (value == "boehm")

--- a/Source/RogueC/RogueC.rogue
+++ b/Source/RogueC/RogueC.rogue
@@ -109,6 +109,7 @@ class RogueC [singleton]
 
     gc_mode = GCMode.AUTO_ST : Int32
     gc_threshold = 1024*1024 : Int32
+    gc_mode_set = false
 
     thread_mode = ThreadMode.NONE : Int32
 
@@ -307,6 +308,10 @@ class RogueC [singleton]
         Program.resolve
         local type_TypeInfo = Program.find_type( "TypeInfo" )
         if (type_TypeInfo) type_TypeInfo.simplify_name = true  # TODO: add general mechanism for having classes simplify their names
+
+        if (thread_mode != ThreadMode.NONE and not gc_mode_set)
+          Console.error.println "NOTE: When specifying --threads, you should also specify a --gc mode."
+        endIf
 
         write_output
 
@@ -631,6 +636,7 @@ $endIf
               else             todo_keywords.add( "TODO" )
 
             case "--gc"
+              gc_mode_set = true
               if ((not value.count) or value == "auto")
                 # Default to AUTO if nothing specified
                 gc_mode = GCMode.AUTO_ST

--- a/Source/RogueC/TokenType.rogue
+++ b/Source/RogueC/TokenType.rogue
@@ -217,6 +217,10 @@ class TokenType
     symbol_vertical_bar_equals    : TokenType
     symbol_double_vertical_bar    : TokenType
 
+    # Noise words
+    keyword_then                  : TokenType
+    keyword_do                    : TokenType
+
   PROPERTIES
     name           : String
     is_end_command : Logical

--- a/Source/RogueC/Tokenizer.rogue
+++ b/Source/RogueC/Tokenizer.rogue
@@ -291,6 +291,10 @@ class Tokenizer
       TokenType.symbol_vertical_bar_equals   = define( ModifyAndAssignTokenType("|=") )
       TokenType.symbol_double_vertical_bar   = define( TokenType("||") )
 
+      # Noise words
+      TokenType.keyword_then                 = define( TokenType("then") )
+      TokenType.keyword_do                   = define( TokenType("do") )
+
     method consume( ch:Character )->Logical
       if (reader.peek != ch) return false
       reader.read

--- a/Source/RogueC/Type.rogue
+++ b/Source/RogueC/Type.rogue
@@ -1017,7 +1017,7 @@ class Type
       endIf
 
       # Add a default to->String to compounds
-      if (is_compound or is_primitive)
+      if ((is_compound or is_primitive) and this is not Program.type_NativeLock)
         local m = find_method( "to_String()" )
         if (not m)
           m = add_method( t, "to_String" )
@@ -1347,6 +1347,8 @@ class Type
       endIf
 
     method create_introspection_methods( scope:Scope )
+      if (this is Program.type_NativeLock) return # Don't introspect NativeLock
+
       # Create type_name() method
       local m_type_name = add_method( t, "type_name" )
       m_type_name.return_type = Program.type_String

--- a/Source/RogueC/Visitor.rogue
+++ b/Source/RogueC/Visitor.rogue
@@ -575,6 +575,12 @@ class Visitor
       on_leave( cmd )
       return cmd
 
+    method visit( cmd:CmdSourceComment )->Cmd
+      on_enter( cmd )
+      dispatch( cmd )
+      on_leave( cmd )
+      return cmd
+
     method on_enter( cmd:Cmd )
       throw RogueError( "$ does not overload method on_enter($)." (type_name,cmd.type_name) )
 
@@ -674,6 +680,7 @@ class Visitor
     method on_enter( cmd:CmdWriteLocal )
     method on_enter( cmd:CmdWriteProperty )
     method on_enter( cmd:CmdWriteSingleton )
+    method on_enter( cmd:CmdSourceComment )
 
     method on_leave( cmd:Cmd )
       throw RogueError( "$ does not overload method on_enter($)." (type_name,cmd.type_name) )
@@ -775,6 +782,7 @@ class Visitor
     method on_leave( cmd:CmdWriteLocal )
     method on_leave( cmd:CmdWriteProperty )
     method on_leave( cmd:CmdWriteSingleton )
+    method on_leave( cmd:CmdSourceComment )
 
     method dispatch( cmd:Cmd )
       throw RogueError( "$ does not overload method dispatch($)." (type_name,cmd.type_name) )
@@ -1212,5 +1220,7 @@ class Visitor
     method dispatch( cmd:CmdIsString )
       cmd.operand = cmd.operand.dispatch( this )
 
+    method dispatch( cmd:CmdSourceComment )
+      noAction
 endClass
 

--- a/Source/Tools/Rogo.rogue
+++ b/Source/Tools/Rogo.rogue
@@ -272,7 +272,7 @@ endRoutine
 routine install_ubuntu_library( library:Value )
   local library_name = library//name->String
 
-  local cmd = ''sudo dpkg -L $ > /dev/null 2>&1'' (library_name)
+  local cmd = ''dpkg -L $ > /dev/null 2>&1'' (library_name)
   println "Checking for library $..." (library_name)
   println(cmd).flush
   if (0 != System.run(cmd))

--- a/Syntax/SublimeText3/syntax/Rogue.tmLanguage
+++ b/Syntax/SublimeText3/syntax/Rogue.tmLanguage
@@ -237,7 +237,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(if|elseIf|else|endIf|contingent|endContingent|satisfied|unsatisfied|try|catch|endTry)\b</string>
+					<string>\b(if|then|elseIf|else|endIf|contingent|endContingent|satisfied|unsatisfied|try|catch|endTry)\b</string>
 					<key>name</key>
 					<string>keyword.control.rogue</string>
 				</dict>
@@ -291,7 +291,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(while|endWhile|forEach|endForEach|in|of|step|await|downTo)\b</string>
+					<string>\b(while|endWhile|forEach|endForEach|in|of|step|await|downTo|do)\b</string>
 					<key>name</key>
 					<string>keyword.loop.rogue</string>
 				</dict>

--- a/Syntax/Vim/syntax/rogue.vim
+++ b/Syntax/Vim/syntax/rogue.vim
@@ -27,14 +27,14 @@ syn keyword rogueClassDecl   nativeCode nativeHeader endNativeCode endNativeHead
 syn keyword rogueMember      ENUMERATE DEFINITIONS SETTINGS CATEGORIES
 syn keyword rogueMember      DEPENDENCIES PROPERTIES METHODS GLOBAL
 syn match   rogueError       "\<for\(\s\|(\)"
-syn keyword rogueConditional  if elseIf else endIf
+syn keyword rogueConditional  if elseIf else endIf then
 syn keyword rogueConditional  which whichIs case caseNext others endWhich endWhichIs
 syn keyword rogueConditional  select
 syn keyword rogueConditional  contingent endContingent satisfied unsatisfied
 syn keyword rogueConditional  block endBlock
 syn keyword rogueConditional  unitTest endUnitTest
 syn keyword rogueLoop         await
-syn keyword rogueLoop         while endWhile forEach endForEach in of step downTo
+syn keyword rogueLoop         while endWhile forEach endForEach in of step downTo do
 syn keyword rogueLoop         loop endLoop
 syn keyword rogueBranch       escapeForEach escapeWhile escapeLoop
 syn keyword rogueBranch       escapeTry escapeUse


### PR DESCRIPTION
Saturday morning onslaught for your review:

- The auto-mt garbage collector is the big bit, of course.  There's a whole series of "mtgc" commits which lead up to it.  These prepare things so that actually adding the collector is all additions and therefore halfway easy to read (rather than a bunch of changes and refactors and additions all mashed together).
- A bunch of fixes to things which got caught by doing full compiles.
- A bunch of thread-related fixes (e.g., singleton initialization race condition)
- A fix for compiling with GCC (had been bothering me for a while!)
- "then" noise word for if statements.
- "do" noise word for while/loop.
- New compiler error if compounds have native properties but no overridden operator==.
- Assorted other fixes/improvements.

For posterity, here's the little [multithreaded test program](https://gist.github.com/MurphyMc/501e4d9972a983702f7aca2434188c06).

In particular, before pulling, you should probably check that the fixes for compiling auto-mt on macOS actually work.

And, again, be sure to click over to the "Commits" tab where things are in a sane order (unlike the Conversation tab).