### PR TITLE
--threads=cpp; init() can be template; GC reentrancy fixes; etc.

### DIFF
--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -26,7 +26,6 @@
 #  include <sys/stat.h>
 #  include <netdb.h>
 #  include <errno.h>
-#  include <pthread.h>
 #endif
 
 #if defined(ANDROID)
@@ -76,19 +75,53 @@ RogueWeakReference* Rogue_weak_references = 0;
 //-----------------------------------------------------------------------------
 #if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
 
+#define ROGUE_EXIT_THREAD pthread_exit(NULL)
+
+#define ROGUE_MUTEX_LOCK(_M) pthread_mutex_lock(&(_M))
+#define ROGUE_MUTEX_UNLOCK(_M) pthread_mutex_unlock(&(_M))
+#define ROGUE_MUTEX_DEF(_N) pthread_mutex_t _N = PTHREAD_MUTEX_INITIALIZER
+
+#define ROGUE_COND_STARTWAIT(_V,_M) ROGUE_MUTEX_LOCK(_M);
+#define ROGUE_COND_DOWAIT(_V,_M,_C) while (_C) pthread_cond_wait(&(_V), &(_M));
+#define ROGUE_COND_ENDWAIT(_V,_M) ROGUE_MUTEX_UNLOCK(_M);
+#define ROGUE_COND_WAIT(_V,_M,_C) \
+  ROGUE_COND_STARTWAIT(_V,_M); \
+  ROGUE_COND_DOWAIT(_V,_M,_C); \
+  ROGUE_COND_ENDWAIT(_V,_M);
+#define ROGUE_COND_DEF(_N) pthread_cond_t _N = PTHREAD_COND_INITIALIZER
+#define ROGUE_COND_NOTIFY_ONE(_V,_M,_C)    \
+  ROGUE_MUTEX_LOCK(_M);                    \
+  _C ;                                     \
+  pthread_cond_signal(&(_V));              \
+  ROGUE_MUTEX_UNLOCK(_M);
+#define ROGUE_COND_NOTIFY_ALL(_V,_M,_C)    \
+  ROGUE_MUTEX_LOCK(_M);                    \
+  _C ;                                     \
+  pthread_cond_broadcast(&(_V));           \
+  ROGUE_MUTEX_UNLOCK(_M);
+
+#define ROGUE_THREAD_DEF(_N) pthread_t _N
+#define ROGUE_THREAD_JOIN(_T) pthread_join(_T, NULL)
+#define ROGUE_THREAD_START(_T, _F) pthread_create(&(_T), NULL, _F, NULL)
+
+#endif
+
+#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
+
 // Thread mutex locks around creation and destruction of threads
-static pthread_mutex_t Rogue_mt_thread_mutex = PTHREAD_MUTEX_INITIALIZER;
+static ROGUE_MUTEX_DEF(Rogue_mt_thread_mutex);
 static int Rogue_mt_tc = 0; // Thread count.  Always set under above lock.
 static std::atomic_bool Rogue_mt_terminating(false); // True when terminating.
 
 static void Rogue_thread_register ()
 {
   // If we're shutting down, no new threads!
-  if (Rogue_mt_terminating.load()) pthread_exit(NULL);
-  pthread_mutex_lock(&Rogue_mt_thread_mutex);
+  if (Rogue_mt_terminating.load()) ROGUE_EXIT_THREAD;
+  ROGUE_MUTEX_LOCK(Rogue_mt_thread_mutex);
   int n = (int)Rogue_mt_tc;
   ++Rogue_mt_tc;
-  pthread_mutex_unlock(&Rogue_mt_thread_mutex);
+  ROGUE_MUTEX_UNLOCK(Rogue_mt_thread_mutex);
+#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
   char name[64];
   sprintf(name, "Thread-%i", n); // Nice names are good for valgrind
 
@@ -99,15 +132,16 @@ static void Rogue_thread_register ()
 #endif
 // It should be possible to get thread names working on lots of other
 // platforms too.  The functions just vary a bit.
+#endif
 }
 
 static void Rogue_thread_unregister ()
 {
   ROGUE_EXIT;
-  pthread_mutex_lock(&Rogue_mt_thread_mutex);
+  ROGUE_MUTEX_LOCK(Rogue_mt_thread_mutex);
   ROGUE_ENTER;
   --Rogue_mt_tc;
-  pthread_mutex_unlock(&Rogue_mt_thread_mutex);
+  ROGUE_MUTEX_UNLOCK(Rogue_mt_thread_mutex);
 }
 
 
@@ -121,13 +155,13 @@ void Rogue_threads_wait_for_all ()
   int wait_step = 1;
   while (true)
   {
-    pthread_mutex_lock(&Rogue_mt_thread_mutex);
+    ROGUE_MUTEX_LOCK(Rogue_mt_thread_mutex);
     if (Rogue_mt_tc <= 1) // Shouldn't ever really be less than 1
     {
-      pthread_mutex_unlock(&Rogue_mt_thread_mutex);
+      ROGUE_MUTEX_UNLOCK(Rogue_mt_thread_mutex);
       break;
     }
-    pthread_mutex_unlock(&Rogue_mt_thread_mutex);
+    ROGUE_MUTEX_UNLOCK(Rogue_mt_thread_mutex);
     usleep(1000 * wait);
     wait_step++;
     if (!(wait_step % 15) && (wait < 500)) wait *= 2; // Max backoff ~500ms
@@ -154,8 +188,8 @@ static void Rogue_thread_unregister ()
 #define ROGUE_SET_SINGLETON(_S,_V) (_S)->_singleton.store(_V);
 #if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
 pthread_mutex_t Rogue_thread_singleton_lock;
-#define ROGUE_SINGLETON_LOCK pthread_mutex_lock(&Rogue_thread_singleton_lock);
-#define ROGUE_SINGLETON_UNLOCK pthread_mutex_unlock(&Rogue_thread_singleton_lock);
+#define ROGUE_SINGLETON_LOCK ROGUE_MUTEX_LOCK(Rogue_thread_singleton_lock);
+#define ROGUE_SINGLETON_UNLOCK ROGUE_MUTEX_UNLOCK(Rogue_thread_singleton_lock);
 #endif
 #else
 #define ROGUE_GET_SINGLETON(_S) (_S)->_singleton
@@ -185,9 +219,9 @@ pthread_mutex_t Rogue_thread_singleton_lock;
 
 // We assume malloc is safe, but the SOA needs safety if it's being used.
 #if ROGUEMM_SMALL_ALLOCATION_SIZE_LIMIT >= 0
-static pthread_mutex_t Rogue_mtgc_soa_mutex = PTHREAD_MUTEX_INITIALIZER;
-#define ROGUE_GC_SOA_LOCK    pthread_mutex_lock(&Rogue_mtgc_soa_mutex);
-#define ROGUE_GC_SOA_UNLOCK  pthread_mutex_unlock(&Rogue_mtgc_soa_mutex);
+static ROGUE_MUTEX_DEF(Rogue_mtgc_soa_mutex);
+#define ROGUE_GC_SOA_LOCK    ROGUE_MUTEX_LOCK(Rogue_mtgc_soa_mutex);
+#define ROGUE_GC_SOA_UNLOCK  ROGUE_MUTEX_UNLOCK(Rogue_mtgc_soa_mutex);
 #else
 #define ROGUE_GC_SOA_LOCK
 #define ROGUE_GC_SOA_UNLOCK
@@ -208,10 +242,10 @@ void Rogue_collect_garbage_real_noinline ()
 
 #define ROGUE_GC_CHECK if (ROGUE_UNLIKELY(Rogue_mtgc_w)) Rogue_mtgc_W2_W3_W4(); // W1
 
-static pthread_mutex_t Rogue_mtgc_w_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t Rogue_mtgc_s_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t Rogue_mtgc_w_cond = PTHREAD_COND_INITIALIZER;
-static pthread_cond_t Rogue_mtgc_s_cond = PTHREAD_COND_INITIALIZER;
+static ROGUE_MUTEX_DEF(Rogue_mtgc_w_mutex);
+static ROGUE_MUTEX_DEF(Rogue_mtgc_s_mutex);
+static ROGUE_COND_DEF(Rogue_mtgc_w_cond);
+static ROGUE_COND_DEF(Rogue_mtgc_s_cond);
 
 ROGUE_GC_VAR Rogue_mtgc_w = 0;
 ROGUE_GC_VAR Rogue_mtgc_s = 0;
@@ -219,27 +253,24 @@ ROGUE_GC_VAR Rogue_mtgc_s = 0;
 // Only one worker can be "running" (waiting for) the GC at a time.
 // To run, set r = 1, and wait for GC to set it to 0.  If r is already
 // 1, just wait.
-static pthread_mutex_t Rogue_mtgc_r_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t Rogue_mtgc_r_cond = PTHREAD_COND_INITIALIZER;
+static ROGUE_MUTEX_DEF(Rogue_mtgc_r_mutex);
+static ROGUE_COND_DEF(Rogue_mtgc_r_cond);
 ROGUE_GC_VAR Rogue_mtgc_r = 0;
 
-static pthread_mutex_t Rogue_mtgc_g_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t Rogue_mtgc_g_cond = PTHREAD_COND_INITIALIZER;
+static ROGUE_MUTEX_DEF(Rogue_mtgc_g_mutex);
+static ROGUE_COND_DEF(Rogue_mtgc_g_cond);
 ROGUE_GC_VAR Rogue_mtgc_g = 0; // Should GC
 
 static int Rogue_mtgc_should_quit = 0; // 0:normal 1:should-quit 2:has-quit
 
-static pthread_t Rogue_mtgc_thread;
+static ROGUE_THREAD_DEF(Rogue_mtgc_thread);
 
 static void Rogue_mtgc_W2_W3_W4 (void);
 static inline void Rogue_mtgc_W3_W4 (void);
 
 inline void Rogue_mtgc_B1 ()
 {
-  pthread_mutex_lock(&Rogue_mtgc_s_mutex);
-  ++Rogue_mtgc_s;
-  pthread_cond_signal(&Rogue_mtgc_s_cond);
-  pthread_mutex_unlock(&Rogue_mtgc_s_mutex);
+  ROGUE_COND_NOTIFY_ONE(Rogue_mtgc_s_cond, Rogue_mtgc_s_mutex, ++Rogue_mtgc_s);
 }
 
 inline void Rogue_mtgc_B2_etc ()
@@ -247,34 +278,26 @@ inline void Rogue_mtgc_B2_etc ()
   Rogue_mtgc_W3_W4();
   // We can probably just do GC_CHECK here rather than this more expensive
   // locking version.
-  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+  ROGUE_MUTEX_LOCK(Rogue_mtgc_w_mutex);
   auto w = Rogue_mtgc_w;
-  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+  ROGUE_MUTEX_UNLOCK(Rogue_mtgc_w_mutex);
   if (ROGUE_UNLIKELY(w)) Rogue_mtgc_W2_W3_W4(); // W1
 }
 
 static inline void Rogue_mtgc_W2 ()
 {
-  pthread_mutex_lock(&Rogue_mtgc_s_mutex);
-  ++Rogue_mtgc_s;
-  pthread_cond_signal(&Rogue_mtgc_s_cond);
-  pthread_mutex_unlock(&Rogue_mtgc_s_mutex);
+  ROGUE_COND_NOTIFY_ONE(Rogue_mtgc_s_cond, Rogue_mtgc_s_mutex, ++Rogue_mtgc_s);
 }
 
 static inline void Rogue_mtgc_W3_W4 ()
 {
   // W3
-  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
-  while (Rogue_mtgc_w != 0)
-  {
-    pthread_cond_wait(&Rogue_mtgc_w_cond, &Rogue_mtgc_w_mutex);
-  }
-  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+  ROGUE_COND_WAIT(Rogue_mtgc_w_cond, Rogue_mtgc_w_mutex, Rogue_mtgc_w != 0);
 
   // W4
-  pthread_mutex_lock(&Rogue_mtgc_s_mutex);
+  ROGUE_MUTEX_LOCK(Rogue_mtgc_s_mutex);
   --Rogue_mtgc_s;
-  pthread_mutex_unlock(&Rogue_mtgc_s_mutex);
+  ROGUE_MUTEX_UNLOCK(Rogue_mtgc_s_mutex);
 }
 
 static void Rogue_mtgc_W2_W3_W4 ()
@@ -320,21 +343,20 @@ inline void Rogue_mtgc_exit()
 static void Rogue_mtgc_M1_M2_GC_M3 (int quit)
 {
   // M1
-  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+  ROGUE_MUTEX_LOCK(Rogue_mtgc_w_mutex);
   Rogue_mtgc_w = 1;
-  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+  ROGUE_MUTEX_UNLOCK(Rogue_mtgc_w_mutex);
 
   // M2
-  pthread_mutex_lock(&Rogue_mtgc_s_mutex);
+#if (ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS) && ROGUE_MTGC_DEBUG
+  ROGUE_MUTEX_LOCK(Rogue_mtgc_s_mutex);
   while (Rogue_mtgc_s != Rogue_mt_tc)
   {
-#if ROGUE_MTGC_DEBUG
     if (Rogue_mtgc_s > Rogue_mt_tc || Rogue_mtgc_s < 0)
     {
       printf("INVALID VALUE OF S %i %i\n", Rogue_mtgc_s, Rogue_mt_tc);
       exit(1);
     }
-#endif
 
     pthread_cond_wait(&Rogue_mtgc_s_cond, &Rogue_mtgc_s_mutex);
   }
@@ -342,12 +364,16 @@ static void Rogue_mtgc_M1_M2_GC_M3 (int quit)
   // very end of the function if we want, and this would prevent
   // threads that were blocking from ever leaving B2.  But
   // We should be okay anyway, though S may temporarily != TC.
-  //pthread_mutex_unlock(&Rogue_mtgc_s_mutex);
+  //ROGUE_MUTEX_UNLOCK(Rogue_mtgc_s_mutex);
+#else
+  ROGUE_COND_STARTWAIT(Rogue_mtgc_s_cond, Rogue_mtgc_s_mutex);
+  ROGUE_COND_DOWAIT(Rogue_mtgc_s_cond, Rogue_mtgc_s_mutex, Rogue_mtgc_s != Rogue_mt_tc);
+#endif
 
 #if ROGUE_MTGC_DEBUG
-  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+  ROGUE_MUTEX_LOCK(Rogue_mtgc_w_mutex);
   Rogue_mtgc_w = 2;
-  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+  ROGUE_MUTEX_UNLOCK(Rogue_mtgc_w_mutex);
 #endif
 
   // GC
@@ -371,11 +397,10 @@ static void Rogue_mtgc_M1_M2_GC_M3 (int quit)
   ROGUE_GC_SOA_UNLOCK;
 
   // M3
-  pthread_mutex_lock(&Rogue_mtgc_w_mutex);
-  Rogue_mtgc_w = 0;
-  pthread_cond_broadcast(&Rogue_mtgc_w_cond);
-  pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
-  pthread_mutex_unlock(&Rogue_mtgc_s_mutex); // Could do much earlier
+  ROGUE_COND_NOTIFY_ALL(Rogue_mtgc_w_cond, Rogue_mtgc_w_mutex, Rogue_mtgc_w = 0);
+
+  // Could have done this much earlier
+  ROGUE_COND_ENDWAIT(Rogue_mtgc_s_cond, Rogue_mtgc_s_mutex);
 }
 
 static void * Rogue_mtgc_threadproc (void *)
@@ -383,31 +408,25 @@ static void * Rogue_mtgc_threadproc (void *)
   int quit = 0;
   while (quit == 0)
   {
-    pthread_mutex_lock(&Rogue_mtgc_g_mutex);
-    while (!Rogue_mtgc_g && !Rogue_mtgc_should_quit)
-    {
-      pthread_cond_wait(&Rogue_mtgc_g_cond, &Rogue_mtgc_g_mutex);
-    }
+    ROGUE_COND_STARTWAIT(Rogue_mtgc_g_cond, Rogue_mtgc_g_mutex);
+    ROGUE_COND_DOWAIT(Rogue_mtgc_g_cond, Rogue_mtgc_g_mutex, !Rogue_mtgc_g && !Rogue_mtgc_should_quit);
     Rogue_mtgc_g = 0;
     quit = Rogue_mtgc_should_quit;
-    pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
+    ROGUE_COND_ENDWAIT(Rogue_mtgc_g_cond, Rogue_mtgc_g_mutex);
 
-    pthread_mutex_lock(&Rogue_mt_thread_mutex);
+    ROGUE_MUTEX_LOCK(Rogue_mt_thread_mutex);
 
     Rogue_mtgc_M1_M2_GC_M3(quit);
 
-    pthread_mutex_unlock(&Rogue_mt_thread_mutex);
+    ROGUE_MUTEX_UNLOCK(Rogue_mt_thread_mutex);
 
-    pthread_mutex_lock(&Rogue_mtgc_r_mutex);
-    Rogue_mtgc_r = 0;
-    pthread_cond_broadcast(&Rogue_mtgc_r_cond);
-    pthread_mutex_unlock(&Rogue_mtgc_r_mutex);
+    ROGUE_COND_NOTIFY_ALL(Rogue_mtgc_r_cond, Rogue_mtgc_r_mutex, Rogue_mtgc_r = 0);
   }
 
-  pthread_mutex_lock(&Rogue_mtgc_g_mutex);
+  ROGUE_MUTEX_LOCK(Rogue_mtgc_g_mutex);
   Rogue_mtgc_should_quit = 2;
   Rogue_mtgc_g = 0;
-  pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
+  ROGUE_MUTEX_UNLOCK(Rogue_mtgc_g_mutex);
   return NULL;
 }
 
@@ -418,16 +437,13 @@ void Rogue_mtgc_run_gc_and_wait ()
   do
   {
     again = false;
-    pthread_mutex_lock(&Rogue_mtgc_r_mutex);
+    ROGUE_COND_STARTWAIT(Rogue_mtgc_r_cond, Rogue_mtgc_r_mutex);
     if (Rogue_mtgc_r == 0)
     {
       Rogue_mtgc_r = 1;
 
       // Signal GC to run
-      pthread_mutex_lock(&Rogue_mtgc_g_mutex);
-      Rogue_mtgc_g = 1;
-      pthread_cond_signal(&Rogue_mtgc_g_cond);
-      pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
+      ROGUE_COND_NOTIFY_ONE(Rogue_mtgc_g_cond, Rogue_mtgc_g_mutex, Rogue_mtgc_g = 1);
     }
     else
     {
@@ -437,11 +453,8 @@ void Rogue_mtgc_run_gc_and_wait ()
       ++Rogue_mtgc_r;
     }
     ROGUE_EXIT;
-    while (Rogue_mtgc_r != 0)
-    {
-      pthread_cond_wait(&Rogue_mtgc_r_cond, &Rogue_mtgc_r_mutex);
-    }
-    pthread_mutex_unlock(&Rogue_mtgc_r_mutex);
+    ROGUE_COND_DOWAIT(Rogue_mtgc_r_cond, Rogue_mtgc_r_mutex, Rogue_mtgc_r != 0);
+    ROGUE_COND_ENDWAIT(Rogue_mtgc_r_cond, Rogue_mtgc_r_mutex);
     ROGUE_ENTER;
   }
   while (again);
@@ -452,31 +465,33 @@ static void Rogue_mtgc_quit_gc_thread ()
   //NOTE: This could probably be simplified (and the quit behavior removed
   //      from Rogue_mtgc_M1_M2_GC_M3) since we now wait for all threads
   //      to stop before calling this.
+  // This doesn't quite use the normal condition variable pattern, sadly.
   ROGUE_EXIT;
+  timespec ts;
+  ts.tv_sec = 0;
+  ts.tv_nsec = 1000000 * 10; // 10ms
   while (true)
   {
-    pthread_mutex_lock(&Rogue_mtgc_g_mutex);
-    if (Rogue_mtgc_should_quit == 2)
+    bool done = true;
+    ROGUE_COND_STARTWAIT(Rogue_mtgc_g_cond, Rogue_mtgc_g_mutex);
+    if (Rogue_mtgc_should_quit != 2)
     {
-      pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
-      break;
+      done = false;
+      Rogue_mtgc_g = 1;
+      Rogue_mtgc_should_quit = 1;
+      pthread_cond_signal(&Rogue_mtgc_g_cond);
     }
-    Rogue_mtgc_g = 1;
-    Rogue_mtgc_should_quit = 1;
-    pthread_cond_signal(&Rogue_mtgc_g_cond);
-    pthread_mutex_unlock(&Rogue_mtgc_g_mutex);
-    timespec ts;
-    ts.tv_sec = 0;
-    ts.tv_nsec = 1000000 * 10; // 10ms
+    ROGUE_COND_ENDWAIT(Rogue_mtgc_g_cond, Rogue_mtgc_g_mutex);
+    if (done) break;
     nanosleep(&ts, NULL);
   }
-  pthread_join(Rogue_mtgc_thread, NULL);
+  ROGUE_THREAD_JOIN(Rogue_mtgc_thread);
   ROGUE_ENTER;
 }
 
 void Rogue_configure_gc()
 {
-  int c = pthread_create(&Rogue_mtgc_thread, NULL, Rogue_mtgc_threadproc, NULL);
+  int c = ROGUE_THREAD_START(Rogue_mtgc_thread, Rogue_mtgc_threadproc);
   if (c != 0)
   {
     exit(77); //TODO: Do something better in this (hopefully) rare case.
@@ -1226,13 +1241,13 @@ void* RogueAllocator_allocate( RogueAllocator* THIS, int size )
 {
 #if ROGUE_GC_MODE_AUTO_MT
 #if ROGUE_MTGC_DEBUG
-    pthread_mutex_lock(&Rogue_mtgc_w_mutex);
+    ROGUE_MUTEX_LOCK(Rogue_mtgc_w_mutex);
     if (Rogue_mtgc_w == 2)
     {
       printf("ALLOC DURING GC!\n");
       exit(1);
     }
-    pthread_mutex_unlock(&Rogue_mtgc_w_mutex);
+    ROGUE_MUTEX_UNLOCK(Rogue_mtgc_w_mutex);
 #endif
 #endif
 

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -76,8 +76,6 @@ RogueWeakReference* Rogue_weak_references = 0;
 //-----------------------------------------------------------------------------
 #if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
 
-#define ROGUE_EXIT_THREAD pthread_exit(NULL)
-
 #define ROGUE_MUTEX_LOCK(_M) pthread_mutex_lock(&(_M))
 #define ROGUE_MUTEX_UNLOCK(_M) pthread_mutex_unlock(&(_M))
 #define ROGUE_MUTEX_DEF(_N) pthread_mutex_t _N = PTHREAD_MUTEX_INITIALIZER
@@ -109,16 +107,6 @@ RogueWeakReference* Rogue_weak_references = 0;
 
 #include <exception>
 #include <condition_variable>
-
-class RogueThreadExitExceptionType: public exception
-{
-  virtual const char * what () const throw()
-  {
-    return "Thread exit exception";
-  }
-} RogueThreadExitException;
-
-#define ROGUE_EXIT_THREAD throw new RogueThreadExitExceptionType()
 
 #define ROGUE_MUTEX_LOCK(_M) _M.lock()
 #define ROGUE_MUTEX_UNLOCK(_M) _M.unlock()
@@ -156,8 +144,6 @@ static std::atomic_bool Rogue_mt_terminating(false); // True when terminating.
 
 static void Rogue_thread_register ()
 {
-  // If we're shutting down, no new threads!
-  if (Rogue_mt_terminating.load()) ROGUE_EXIT_THREAD;
   ROGUE_MUTEX_LOCK(Rogue_mt_thread_mutex);
 #if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
   int n = (int)Rogue_mt_tc;

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -1924,10 +1924,10 @@ static inline void Rogue_collect_garbage_real()
   Rogue_gc_requested = false;
   ++ Rogue_gc_count;
 
-  Rogue_on_gc_begin.call();
-
 //printf( "GC %d\n", Rogue_allocation_bytes_until_gc );
   ROGUE_GC_RESET_COUNT;
+
+  Rogue_on_gc_begin.call();
 
   Rogue_trace();
 

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -1264,6 +1264,7 @@ void* RogueAllocationPage_allocate( RogueAllocationPage* THIS, int size )
   void* result = THIS->cursor;
   THIS->cursor += size;
   THIS->remaining -= size;
+  ((RogueObject*)result)->reference_count = 0;
 
   //printf( "%d / %d\n", ROGUEMM_PAGE_SIZE - remaining, ROGUEMM_PAGE_SIZE );
   return result;
@@ -1473,14 +1474,15 @@ RogueObject* RogueAllocator_allocate_object( RogueAllocator* THIS, RogueType* of
 #else
 RogueObject* RogueAllocator_allocate_object( RogueAllocator* THIS, RogueType* of_type, int size, int element_type_index )
 {
-  ROGUE_DEF_LOCAL_REF(RogueObject*, obj, (RogueObject*) RogueAllocator_allocate( THIS, size ));
+  void * mem = RogueAllocator_allocate( THIS, size );
+  memset( mem, 0, size );
+
+  ROGUE_DEF_LOCAL_REF(RogueObject*, obj, (RogueObject*)mem);
 
   ROGUE_GCDEBUG_STATEMENT( printf( "Allocating " ) );
   ROGUE_GCDEBUG_STATEMENT( RogueType_print_name(of_type) );
   ROGUE_GCDEBUG_STATEMENT( printf( " %p\n", (RogueObject*)obj ) );
   //ROGUE_GCDEBUG_STATEMENT( Rogue_print_stack_trace() );
-
-  memset( obj, 0, size );
 
   obj->type = of_type;
   obj->object_size = size;

--- a/Source/Libraries/Standard/NativeCPP.cpp
+++ b/Source/Libraries/Standard/NativeCPP.cpp
@@ -58,6 +58,7 @@ bool               Rogue_gc_logging   = false;
 int                Rogue_gc_threshold = ROGUE_GC_THRESHOLD_DEFAULT;
 int                Rogue_gc_count     = 0; // Purely informational
 bool               Rogue_gc_requested = false;
+bool               Rogue_gc_active    = false; // Are we collecting right now?
 RogueLogical       Rogue_configured = 0;
 int                Rogue_argc;
 const char**       Rogue_argv;
@@ -1922,6 +1923,8 @@ bool Rogue_collect_garbage( bool forced )
 static inline void Rogue_collect_garbage_real()
 {
   Rogue_gc_requested = false;
+  if (Rogue_gc_active) return;
+  Rogue_gc_active = true;
   ++ Rogue_gc_count;
 
 //printf( "GC %d\n", Rogue_allocation_bytes_until_gc );
@@ -1937,6 +1940,7 @@ static inline void Rogue_collect_garbage_real()
   }
 
   Rogue_on_gc_end.call();
+  Rogue_gc_active = false;
 }
 
 #endif

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -61,22 +61,12 @@
 // ROGUE_BLOCKING_ENTER/EXIT do the same things but with the meanings reversed
 // in case this makes it easier to think about.  An even easier way to make
 // a blocking call is to simply wrap it in ROGUE_BLOCKING_CALL(foo(...)).
-// The FAST variants are faster, but you need to be careful that they are
-// exactly balanced.
-// Of special note is that in the event handler case, you should have
-// ROGUE_EXITed before the first event handler.  If you're using the FAST
-// variants and don't do this, things will likely go quite badly for you.
 
 #if ROGUE_GC_MODE_AUTO_MT
 
 #define ROGUE_ENTER Rogue_mtgc_enter()
 #define ROGUE_EXIT  Rogue_mtgc_exit()
 
-#define ROGUE_ENTER_FAST Rogue_mtgc_B2_etc()
-#define ROGUE_EXIT_FAST  Rogue_mtgc_B1()
-
-inline void Rogue_mtgc_B1 (void);
-inline void Rogue_mtgc_B2_etc (void);
 inline void Rogue_mtgc_enter (void);
 inline void Rogue_mtgc_exit (void);
 
@@ -89,8 +79,6 @@ template<typename RT> RT Rogue_mtgc_reenter (RT expr);
 
 #define ROGUE_ENTER
 #define ROGUE_EXIT
-#define ROGUE_ENTER_FAST
-#define ROGUE_EXIT_FAST
 
 #define ROGUE_BLOCKING_CALL(__x) __x
 

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -373,6 +373,35 @@ public:
 #define ROGUE_SYNC_OBJECT_ENTER RogueUnlocker _unlocker(THIS->_object_mutex);
 #define ROGUE_SYNC_OBJECT_EXIT
 
+#elif ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_CPP
+
+#include <thread>
+#include <mutex>
+#include <atomic>
+
+#define ROGUE_THREAD_LOCAL thread_local
+
+class RogueUnlocker
+{
+  std::recursive_mutex & mutex;
+public:
+  RogueUnlocker(std::recursive_mutex & mutex)
+  : mutex(mutex)
+  {
+    mutex.lock();
+  }
+  ~RogueUnlocker (void)
+  {
+    mutex.unlock();
+  }
+};
+
+#define ROGUE_SYNC_OBJECT_TYPE std::recursive_mutex
+#define ROGUE_SYNC_OBJECT_INIT
+#define ROGUE_SYNC_OBJECT_CLEANUP
+#define ROGUE_SYNC_OBJECT_ENTER RogueUnlocker _unlocker(THIS->_object_mutex);
+#define ROGUE_SYNC_OBJECT_EXIT
+
 #else
 
 #define ROGUE_SYNC_OBJECT_TYPE
@@ -500,7 +529,7 @@ struct RogueType
   const int*   property_type_indices;
   const int*   property_offsets;
 
-#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
+#if (ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS) || (ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_CPP)
   std::atomic<RogueObject*> _singleton;
 #else
   RogueObject* _singleton;

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -325,12 +325,7 @@ T rogue_ptr (T p)
 //  Threading
 //-----------------------------------------------------------------------------
 
-#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
-
-#include <pthread.h>
-#include <atomic>
-
-#define ROGUE_THREAD_LOCAL thread_local
+#if ROGUE_THREAD_MODE != ROGUE_THREAD_MODE_NONE
 
 #if ROGUE_GC_MODE_BOEHM
   #define ROGUE_THREAD_LOCALS_INIT(__first, __last) GC_add_roots((void*)&(__first), (void*)((&(__last))+1));
@@ -339,6 +334,15 @@ T rogue_ptr (T p)
   #define ROGUE_THREAD_LOCALS_INIT(__first, __last)
   #define ROGUE_THREAD_LOCALS_DEINIT(__first, __last)
 #endif
+
+#endif
+
+#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
+
+#include <pthread.h>
+#include <atomic>
+
+#define ROGUE_THREAD_LOCAL thread_local
 
 static inline void _rogue_init_mutex (pthread_mutex_t * mutex)
 {

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -81,6 +81,7 @@ template<typename RT> RT Rogue_mtgc_reenter (RT expr);
 #define ROGUE_EXIT
 
 #define ROGUE_BLOCKING_CALL(__x) __x
+#define ROGUE_BLOCKING_VOID_CALL(__x)
 
 #endif
 

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -341,6 +341,10 @@ class Mutex
     method lock [macro]
       native "ROGUE_BLOCKING_CALL(pthread_mutex_lock(&$this->_lock));"
 
+    method try_lock () -> Logical
+      # Returns true if we got the lock
+      return native("pthread_mutex_trylock(&$this->_lock)")->Int == 0
+
     method on_end_use
       unlock
 

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -1,15 +1,13 @@
 # Rogue thread library
 
-# Currently only supports pthreads and g++-like compilers.
+$if THREAD_MODE != "NONE"
 
 nativeHeader
 
-#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
-
-// #include "gc.h" - included elsewhere
-#include <pthread.h>
-#include <assert.h>
 #include <functional>
+#include <assert.h>
+
+#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
 
 // Platform-appropriate semaphore
 // Based on https://stackoverflow.com/a/27847103/135791
@@ -98,6 +96,94 @@ RogueSemaphore_destroy( struct RogueSemaphore *s )
 #endif
 }
 
+#elif ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_CPP
+
+#include <mutex>
+#include <condition_variable>
+
+// From https://stackoverflow.com/questions/4792449
+class RogueSemaphoreType
+{
+private:
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    unsigned long count_ = 0; // Initialized as locked.
+
+public:
+    void set(unsigned long count) {
+      count_ = count;
+    }
+
+    void notify() {
+        std::unique_lock<decltype(mutex_)> lock(mutex_);
+        ++count_;
+        condition_.notify_one();
+    }
+
+    void wait() {
+        std::unique_lock<decltype(mutex_)> lock(mutex_);
+        while(!count_) // Handle spurious wake-ups.
+            condition_.wait(lock);
+        --count_;
+    }
+
+    bool try_wait() {
+        std::unique_lock<decltype(mutex_)> lock(mutex_);
+        if(count_) {
+            --count_;
+            return true;
+        }
+        return false;
+    }
+};
+
+struct RogueSemaphore
+{
+    RogueSemaphoreType sem;
+};
+
+
+static inline void
+RogueSemaphore_init( struct RogueSemaphore *s, uint32_t value )
+{
+    s->sem.set(value);
+}
+
+static inline void
+RogueSemaphore_wait( struct RogueSemaphore *s )
+{
+  s->sem.wait();
+}
+
+// Returns true if semaphore was decremented.
+static inline bool
+RogueSemaphore_try_wait( struct RogueSemaphore *s )
+{
+  return s->sem.try_wait();
+}
+
+static inline void
+RogueSemaphore_post(struct RogueSemaphore *s)
+{
+  s->sem.notify();
+}
+
+static inline void
+RogueSemaphore_destroy( struct RogueSemaphore *s )
+{
+}
+
+#endif
+
+struct thread_start_info
+{
+  std::function<void()> thread_function;
+  RogueSemaphore sem;
+};
+
+
+#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
+
 pthread_t create_thread (void * (*f)(void *), void * arg)
 {
   pthread_t tid;
@@ -106,13 +192,6 @@ pthread_t create_thread (void * (*f)(void *), void * arg)
   assert(tid != 0);
   return tid;
 }
-
-struct thread_start_info
-{
-  std::function<void()> thread_function;
-  RogueSemaphore sem;
-};
-
 
 static inline void * roguethread_entry (void * tsi_)
 {
@@ -123,8 +202,37 @@ static inline void * roguethread_entry (void * tsi_)
   return NULL;
 }
 
-
 pthread_t roguethread_create ( std::function<void()> f )
+{
+  thread_start_info si = {};
+  si.thread_function = f;
+  RogueSemaphore_init( &si.sem, 0 );
+  auto r = create_thread(roguethread_entry, &si);
+  RogueSemaphore_wait(&si.sem);
+  RogueSemaphore_destroy(&si.sem);
+  return r;
+}
+
+#elif ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_CPP
+
+#define ROGUE_THREADS_TYPE std::thread
+
+ROGUE_THREADS_TYPE create_thread (void * (*f)(void *), void * arg)
+{
+  ROGUE_THREADS_TYPE tid = std::thread(f, arg);
+  return tid;
+}
+
+static inline void * roguethread_entry (void * tsi_)
+{
+  thread_start_info & si = *(thread_start_info *)tsi_;
+  auto thread_function = si.thread_function;
+  RogueSemaphore_post(&si.sem); // We've got it.
+  thread_function();
+  return NULL;
+}
+
+ROGUE_THREADS_TYPE roguethread_create ( std::function<void()> f )
 {
   thread_start_info si = {};
   si.thread_function = f;
@@ -191,33 +299,61 @@ $endIf
 
 class Thread
   PROPERTIES
+$if THREAD_MODE == "PTHREADS"
     native "pthread_t thread;" # We assume 0 is invalid
+$else
+    native "std::thread thread;"
+$endIf
 
   METHODS
     method has_thread () -> Logical
+$if THREAD_MODE == "PTHREADS"
       return native("$this->thread")->Logical
+$else
+      # This is really just checking if it's joinable
+      return native("$this->thread.get_id() != std::thread::id()")->Logical
+$endIf
 
     method join ()
       if (not has_thread) return
+$if THREAD_MODE == "PTHREADS"
       native @|ROGUE_EXIT;
               |pthread_join($this->thread, NULL);
               |ROGUE_ENTER;
+$elseIf THREAD_MODE == "CPP"
+      native @|ROGUE_EXIT;
+              |$this->thread.join();
+              |ROGUE_ENTER;
+$endIf
 
     method detach ()
       if (not has_thread) return
+$if THREAD_MODE == "PTHREADS"
       native @|pthread_detach($this->thread);
               |$this->thread = (pthread_t)0;
+$elseIf THREAD_MODE == "CPP"
+     native @|$this->thread.detach();
+$endIf
 
     method is_current () -> Logical
       # Doesn't necessarily work for all types of threads
+$if THREAD_MODE == "PTHREADS"
       if (not has_thread) return false
       return this == Thread.current
+$else
+      return native("std::this_thread::get_id() == $this->thread.get_id()")->Logical
+$endIf
 
     method operator== (other:Thread) -> Logical
       # Not all kinds of threads can necessarily do this.
       local eq = 0
+$if THREAD_MODE == "PTHREADS"
       native @|$eq = ($this->thread == $other->thread);
+$else
+      native @|$eq = ($this->thread.get_id() == $other->thread.get_id());
+$endIf
       return eq
+
     method to -> String
       if (not has_thread)
         return "($ detached)" (type_info.name)
@@ -260,20 +396,28 @@ class Thread
       native @|ROGUE_THREAD_LAMBDA_END($f)
               |$this->thread = roguethread_create(f);
 
+$if THREAD_MODE == "PTHREADS"
     method init () -> Thread [essential]
       native @|$this->thread = pthread_self();
+$endIf
 
     method on_cleanup ()
       detach
 
     method id () -> Int64
       #TODO: Do nice (but OS-specific) stuff to get a reasonable ID
+$if THREAD_MODE == "PTHREADS"
       if (not has_thread) return 0
       return native("$this->thread")->Int64
+$else
+      return native("$this")->Int64
+$endIf
 
   GLOBAL METHODS
+$if THREAD_MODE == "PTHREADS"
     method current () -> Thread [essential]
       return Thread()
+$endIf
 
 endClass
 
@@ -281,9 +425,16 @@ endClass
 augment Exception
   METHODS
     method display
+$if THREAD_MODE == "PTHREADS"
       message = "In thread " + Thread.current.id + "\n" + message
+$else
+      #TODO: It'd be nice to print some sort of thread ID!
+      message = "In thread <Unknown>\n" + message
+$endIf
 endAugment
 
+
+$if (THREAD_MODE == "PTHREADS")
 
 #{
   FastBarrier is a lightweight barrier *that cannot be copied*.
@@ -352,7 +503,6 @@ class Mutex
       native "pthread_mutex_unlock(&$this->_lock);"
 endClass
 
-
 class SpinLock
   PROPERTIES
     native "pthread_spinlock_t _lock;"
@@ -377,6 +527,38 @@ class SpinLock
     method unlock [macro]
       native "pthread_spin_unlock(&$this->_lock);"
 endClass
+
+$elseIf THREAD_MODE == "CPP"
+
+class Mutex
+  PROPERTIES
+    native "std::mutex * _lock;"
+
+  METHODS
+    method init
+      native "$this->_lock = new std::mutex();"
+
+    method on_cleanup
+      native "delete $this->_lock;"
+
+    method on_use -> this
+      lock
+      return this
+
+    method lock [macro]
+      native "ROGUE_BLOCKING_VOID_CALL($this->_lock->lock());"
+
+    method try_lock () -> Logical
+      return native("$this->_lock->try_lock()")->Logical
+
+    method on_end_use
+      unlock
+
+    method unlock [macro]
+      native "$this->_lock->unlock();"
+endClass
+
+$endIf
 
 
 class SimpleSpinLock [compound]
@@ -458,3 +640,5 @@ class Semaphore
     method on_end_use
       release
 endClass
+
+$endIf

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -116,12 +116,10 @@ struct thread_start_info
 
 static inline void * roguethread_entry (void * tsi_)
 {
-  thread_start_info * tsi = (thread_start_info *)tsi_;
-  // We're not currently really using the semaphore, but it might
-  // be useful in the future.
-  thread_start_info si = *tsi;
-  RogueSemaphore_post(&tsi->sem); // We've got it.
-  si.thread_function();
+  thread_start_info & si = *(thread_start_info *)tsi_;
+  auto thread_function = si.thread_function;
+  RogueSemaphore_post(&si.sem); // We've got it.
+  thread_function();
   return NULL;
 }
 
@@ -191,75 +189,89 @@ $else
 $endIf
 
 
-# A limitation of the current implementation is that it assumes that a
-# pthread_t can safely be cast back and forth with an Int64.
+class Thread
+  PROPERTIES
+    native "pthread_t thread;" # We assume 0 is invalid
 
-class Thread (id:Int64) [compound]
   METHODS
+    method has_thread () -> Logical
+      return native("$this->thread")->Logical
+
     method join ()
+      if (not has_thread) return
       native @|ROGUE_EXIT;
-              |pthread_join((pthread_t)$this.id, NULL);
+              |pthread_join($this->thread, NULL);
               |ROGUE_ENTER;
 
     method detach ()
-      native @|pthread_detach((pthread_t)$this.id);
+      if (not has_thread) return
+      native @|pthread_detach($this->thread);
+              |$this->thread = (pthread_t)0;
 
     method is_current () -> Logical
+      # Doesn't necessarily work for all types of threads
+      if (not has_thread) return false
       return this == Thread.current
 
+    method operator== (other:Thread) -> Logical
+      # Not all kinds of threads can necessarily do this.
+      local eq = 0
+      native @|$eq = ($this->thread == $other->thread);
+      return eq
     method to -> String
+      if (not has_thread)
+        return "($ detached)" (type_info.name)
+      endIf
       return "($ $)" (type_info.name, id)
 
     method pin_to_core (core:Int32) -> Logical
+      if (not has_thread) return false
       local ok = 0
-      native @|//#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
+      native @|#if ROGUE_THREAD_MODE == ROGUE_THREAD_MODE_PTHREADS
               |  $ok = 1;
               |  cpu_set_t cpus;
               |  CPU_ZERO(&cpus);
               |  CPU_SET($core, &cpus);
-              |  pthread_setaffinity_np((pthread_t)$this.id, sizeof(cpus), &cpus);
-              |//#endif
+              |  pthread_setaffinity_np($this->thread, sizeof(cpus), &cpus);
+              |#endif
       return ok
 
-  GLOBAL METHODS
-
-    method create (f:Function()) -> Thread
-      local r : Int64
+    method init (f:Function())
       native @|ROGUE_THREAD_LAMBDA_START($f)
-      f()
+        f()
       native @|ROGUE_THREAD_LAMBDA_END($f)
-              |$r = (RogueInt64)roguethread_create(f);
-      return Thread(r)
+              |$this->thread = roguethread_create(f);
 
-    method create <<$T1>> (f:Function($T1), a1:$T1) -> Thread
-      local r : Int64
+    method init <<$T1>> (f:Function($T1), a1:$T1)
       native @|ROGUE_THREAD_LAMBDA_START($f)
         f(a1)
       native @|ROGUE_THREAD_LAMBDA_END($f)
-              |$r = (RogueInt64)roguethread_create(f);
-      return Thread(r)
+              |$this->thread = roguethread_create(f);
 
-    method create <<$T1,$T2>> (f:Function($T1,$T2), a1:$T1, a2:$T2) -> Thread
-      local r : Int64
+    method init <<$T1,$T2>> (f:Function($T1,$T2), a1:$T1, a2:$T2)
       native @|ROGUE_THREAD_LAMBDA_START($f)
         f(a1,a2)
       native @|ROGUE_THREAD_LAMBDA_END($f)
-              |$r = (RogueInt64)roguethread_create(f);
-      return Thread(r)
+              |$this->thread = roguethread_create(f);
 
-    method create <<$T1,$T2,$T3>> (f:Function($T1,$T2,$T3), a1:$T1, a2:$T2, a3:$T3) -> Thread
-      local r : Int64
+    method init <<$T1,$T2,$T3>> (f:Function($T1,$T2,$T3), a1:$T1, a2:$T2, a3:$T3)
       native @|ROGUE_THREAD_LAMBDA_START($f)
         f(a1,a2,a3)
       native @|ROGUE_THREAD_LAMBDA_END($f)
-              |$r = (RogueInt64)roguethread_create(f);
-      return Thread(r)
+              |$this->thread = roguethread_create(f);
 
-    method create () -> Thread [essential]
-      local r : Int64
-      native @|$r = (RogueInt64)pthread_self();
-      return Thread(r)
+    method init () -> Thread [essential]
+      native @|$this->thread = pthread_self();
 
+    method on_cleanup ()
+      detach
+
+    method id () -> Int64
+      #TODO: Do nice (but OS-specific) stuff to get a reasonable ID
+      if (not has_thread) return 0
+      return native("$this->thread")->Int64
+
+  GLOBAL METHODS
     method current () -> Thread [essential]
       return Thread()
 
@@ -269,7 +281,7 @@ endClass
 augment Exception
   METHODS
     method display
-      message = "In thread " + Thread.current.id->Int32 + "\n" + message
+      message = "In thread " + Thread.current.id + "\n" + message
 endAugment
 
 

--- a/Source/Libraries/Standard/Thread.rogue
+++ b/Source/Libraries/Standard/Thread.rogue
@@ -266,6 +266,7 @@ inline void roguethread_simple_spin_unlock(int volatile *p)
 #define ROGUE_THREAD_LAMBDA_START(__f) \
   RogueObject_retain(__f);                                                                        \
   std::function<void()> f = [=] () {                                                              \
+    if (Rogue_mt_terminating.load()) return; /* No new threads if shutting down */                \
     Rogue_thread_register();                                                                      \
     Rogue_init_thread();                                                                          \
     ROGUE_THREAD_DEBUG_STATEMENT(RogueDebugTrace __trace( "Thread.lambda()", "thread.rogue", 1)); \

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -1942,6 +1942,10 @@ augment RogueC
                   |#endif
           if (RogueC.thread_mode == ThreadMode.PTHREADS)
             compiler_name += " -pthread"
+          elseIf (RogueC.thread_mode == ThreadMode.CPP)
+            if (not RogueC.compile_targets["Windows"])
+              compiler_name += " -pthread"
+            endIf
           endIf
         endIf
 

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -2342,8 +2342,6 @@ augment Method
         endIf
       endForEach
 
-      writer.println "ROGUE_GC_CHECK;"
-
       if (type_context.is_aspect and not is_global)
         writer.println( "switch (THIS->type->index)" );
         writer.println "{"
@@ -2387,6 +2385,7 @@ augment Method
           writer.print( t.filename ).print( ''", '' ).print( t.line )
           writer.println( '' );'' )
         endIf
+        if (statements.count > 1) writer.println "ROGUE_GC_CHECK;"
         statements.write_cpp( writer )
       endIf
 

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -222,8 +222,7 @@ augment Program
       writer.println "#define ROGUE_THREAD_MODE_NONE 0"
       writer.println "#define ROGUE_THREAD_MODE_PTHREADS 1"
       writer.println "#ifndef ROGUE_THREAD_MODE"
-      writer.print   "  #define ROGUE_THREAD_MODE ROGUE_THREAD_MODE_"
-      writer.println select{RogueC.thread_mode == ThreadMode.NONE: "NONE" || "PTHREADS"}
+      writer.println "  #define ROGUE_THREAD_MODE ROGUE_THREAD_MODE_" + RogueC.thread_mode->String
       writer.println "#endif"
 
       # Enable Introspection?

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -221,6 +221,7 @@ augment Program
       # Thread mode stuff
       writer.println "#define ROGUE_THREAD_MODE_NONE 0"
       writer.println "#define ROGUE_THREAD_MODE_PTHREADS 1"
+      writer.println "#define ROGUE_THREAD_MODE_CPP 2"
       writer.println "#ifndef ROGUE_THREAD_MODE"
       writer.println "  #define ROGUE_THREAD_MODE ROGUE_THREAD_MODE_" + RogueC.thread_mode->String
       writer.println "#endif"

--- a/Source/RogueC/Cmd.rogue
+++ b/Source/RogueC/Cmd.rogue
@@ -2912,6 +2912,12 @@ class CmdCall : Cmd
     method require_type->Type
       local result = type
       if (result is null)
+        if (method_info.name.before_first("<") == "init" and method_info.type_context)
+          # init is a template method.  We let people get away without specifying the return
+          # type for init methods -- it's just the type of the class.
+          method_info.return_type = method_info.type_context
+          return method_info.type_context
+        endIf
         throw t.error( "Value expected; call to $.$ does not return a value." (method_info.type_context,method_info.signature) )
       endIf
       return result

--- a/Source/RogueC/Method.rogue
+++ b/Source/RogueC/Method.rogue
@@ -242,7 +242,7 @@ class Method
       if (organized) return this
       organized = true
 
-      if (name == "init")
+      if (name.before_first('<') == "init")
         if (is_global)
           throw t.error( "init() methods cannot be global methods.  Rename your method init_class() if you need to perform class setup." )
         elseIf (type_context.is_compound)

--- a/Source/RogueC/RogueC.rogue
+++ b/Source/RogueC/RogueC.rogue
@@ -42,11 +42,12 @@ class GCMode
     BOEHM_TYPED
 endClass
 
-class ThreadMode
-  ENUMERATE
+enum ThreadMode
+  CATEGORIES
     NONE
     PTHREADS
-endClass
+    CPP
+endEnum
 
 
 class RogueC [singleton]
@@ -110,7 +111,7 @@ class RogueC [singleton]
     gc_threshold = 1024*1024 : Int32
     gc_mode_set = false
 
-    thread_mode = ThreadMode.NONE : Int32
+    thread_mode = ThreadMode.NONE
 
     plugins = Plugin[]
 

--- a/Source/RogueC/RogueC.rogue
+++ b/Source/RogueC/RogueC.rogue
@@ -267,6 +267,7 @@ class RogueC [singleton]
                     |    The threading mode may be one of:
                     |      --threads=none     - No multithreading support. (Default)
                     |      --threads=pthreads - Multithreading based on pthreads.
+                    |      --threads=cpp        Multithreading based on C++ std::thread.
                     |
                     |  --todo[="KEYWORD"]
                     |    During compilation the compiler will print out any lines containing a
@@ -671,6 +672,8 @@ $endIf
               if ((not value.count) or value == "pthreads")
                 # Default to pthreads if nothing specified
                 thread_mode = ThreadMode.PTHREADS
+              elseIf (value == "cpp")
+                thread_mode = ThreadMode.CPP
               elseIf (value == "none")
                 thread_mode = ThreadMode.NONE
               else
@@ -719,7 +722,6 @@ $endIf
           source_files.add( arg )
         endIf
       endForEach
-
 
     method require_valueless( arg:String, expecting:String )
       if (arg == expecting) return


### PR DESCRIPTION
Adds a new thread mode based on C++ standard threads instead of pthreads. It's not quite as functional, so pthreads is preferable when available, but this should be more portable. I am looking at you, Windows.