### PR TITLE
Windows support, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ exhaustive: roguec
 	rogo version
 	cd Source/RogueC && roguec RogueC.rogue --gc=manual --main --output=Build/RogueC --api=* $(ROGUEC_ROGUE_FLAGS) --define=NO_LIBFFI --threads
 	mkdir -p Programs
-	$(CXX) $(ROGUEC_CPP_FLAGS) -DDEFAULT_CXX="$(DEFAULT_CXX)" Source/RogueC/Build/RogueC.cpp -o Programs/RogueC/$(PLATFORM)/roguec
+	$(CXX) -pthread $(ROGUEC_CPP_FLAGS) -DDEFAULT_CXX="$(DEFAULT_CXX)" Source/RogueC/Build/RogueC.cpp -o Programs/RogueC/$(PLATFORM)/roguec
 
 roguec: bootstrap_roguec $(BINDIR)/roguec libraries rogo Source/RogueC/Version.rogue Source/RogueC/Build/RogueC.cpp Programs/RogueC/$(PLATFORM)/roguec
 

--- a/Source/Libraries/Standard/Console.rogue
+++ b/Source/Libraries/Standard/Console.rogue
@@ -1,7 +1,27 @@
+$if (defined(CONSOLE_BAREBONES))
+$localDefine CONSOLE_FULL false
+$else
+$localDefine CONSOLE_FULL true
+$endIf
+
 class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
   DEPENDENCIES
+$if (CONSOLE_FULL)
     nativeHeader #include <termios.h>
     nativeHeader #include <unistd.h>
+$endIf
+  nativeHeader
+    #ifndef STDIN_FILENO     /* Probably Windows */
+      #define STDIN_FILENO 0 /* Probably correct */
+    #endif
+    #if defined(ROGUE_PLATFORM_WINDOWS)
+      #include <io.h>
+      #define ROGUE_READ_CALL _read
+    #else
+      #define ROGUE_READ_CALL read
+    #endif
+
+  endNativeHeader
 
   ENUMERATE
     UP_ARROW    = 17
@@ -42,15 +62,19 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
     next_input_character : Int32?
     input_bytes          = Byte[]
 
+$if (CONSOLE_FULL)
     native "termios original_terminal_settings;"
     native "int     original_stdin_flags;"
+$endIf
 
   METHODS
     method init
+$if (CONSOLE_FULL)
       native @|tcgetattr( STDIN_FILENO, &$this->original_terminal_settings );
               |$this->original_stdin_flags = fcntl( STDIN_FILENO, F_GETFL );
 
       on_exit( function with (console=this) => console.reset_input_mode )
+$endIf
 
     method clear
       print( "\e[2J" ).flush
@@ -62,7 +86,7 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
       # Internal use
       local n : Int32
       native @|char bytes[8];
-              |$n = (RogueInt32) read( STDIN_FILENO, &bytes, 8 );
+              |$n = (RogueInt32) ROGUE_READ_CALL( STDIN_FILENO, &bytes, 8 );
       if (n > 0)
         forEach (i in 0..<n)
           input_bytes.add( native("((RogueByte)bytes[$i])")->Byte )
@@ -142,6 +166,7 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
       return next_input_character.exists
 
     method height->Int32
+$if (CONSOLE_FULL)
       nativeHeader #include <sys/ioctl.h>
       nativeHeader #include <unistd.h>
 
@@ -149,6 +174,9 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
               |ioctl( STDOUT_FILENO, TIOCGWINSZ, &sz );
               |
               |return sz.ws_row;
+$else
+      return 24
+$endIf
 
     method move_cursor( dx:Int32, dy:Int32 )
       if (dx)
@@ -188,13 +216,16 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
       return read_line
 
     method reset_input_mode
+$if (CONSOLE_FULL)
       native @|tcsetattr( STDIN_FILENO, TCSANOW, &$this->original_terminal_settings );
               |fcntl( STDIN_FILENO, F_SETFL, $this->original_stdin_flags );
+$endIf
 
     method restore_cursor_position
       print( "\e[u" ).flush
 
     method set_is_blocking( setting:Logical )->this
+$if (CONSOLE_FULL)
       if (@is_blocking != setting)
         @is_blocking = setting
         if (@is_blocking)
@@ -204,6 +235,7 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
         endIf
       endIf
       return this
+$endIf
 
     method save_cursor_position
       print( "\e[s" ).flush
@@ -212,6 +244,7 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
       print( "\e[" ).print( y ).print( ';' ).print( x ).print( 'H' ).flush
 
     method set_immediate_mode( setting:Logical )->this
+$if (CONSOLE_FULL)
       if (@immediate_mode != setting)
         @immediate_mode = setting
         if (@immediate_mode)
@@ -228,9 +261,11 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
           native @|tcsetattr( STDIN_FILENO, TCSANOW, &$this->original_terminal_settings );
         endIf
       endIf
+$endIf
       return this
 
     method width->Int32
+$if (CONSOLE_FULL)
       nativeHeader #include <sys/ioctl.h>
       nativeHeader #include <unistd.h>
 
@@ -238,6 +273,9 @@ class Console : Reader<<Character>>, PrintWriter<<output_buffer>> [singleton]
               |ioctl( STDOUT_FILENO, TIOCGWINSZ, &sz );
               |
               |return sz.ws_col;
+$else
+      return 80
+$endIf
 
     method write( value:String )->this
       native @|fwrite( $value->utf8, 1, $value->byte_count, stdout );

--- a/Source/Libraries/Standard/File.rogue
+++ b/Source/Libraries/Standard/File.rogue
@@ -219,7 +219,11 @@ class File
       if (not create_folder(parent)) return false
 
       # Note: 0777 is a permission mask rather than the actual permission setting.
-      native @|return (0 == mkdir((char*)$filepath->utf8, 0777));
+      native @|#if defined(ROGUE_PLATFORM_WINDOWS)
+              |  return (0 == mkdir((char*)$filepath->utf8));
+              |#else
+              |  return (0 == mkdir((char*)$filepath->utf8, 0777));
+              |#endif
 
     method delete( filepath:String )->Logical
       if (not filepath) return false

--- a/Source/Libraries/Standard/File.rogue
+++ b/Source/Libraries/Standard/File.rogue
@@ -236,11 +236,8 @@ class File
     method exists( filepath:String )->Logical
       native @|if ( !$filepath ) return false;
               |
-              |FILE* fp = fopen( (char*)$filepath->utf8, "rb" );
-              |if ( !fp ) return false;
-              |
-              |fclose( fp );
-              |return true;
+              |struct stat s;
+              |return (stat((char*)$filepath->utf8, &s) == 0);
 
     method extension( filepath:String )->String
       return filepath.after_last( '.' )

--- a/Source/Libraries/Standard/File.rogue
+++ b/Source/Libraries/Standard/File.rogue
@@ -234,7 +234,7 @@ class File
 
     method ensure_ends_with_separator( filepath:String )->String
       if (ends_with_separator(filepath)) return filepath
-      return filepath + '/'
+      return filepath + separator
 
     method exists( filepath:String )->Logical
       native @|if ( !$filepath ) return false;
@@ -595,7 +595,11 @@ class File
       return not outfile.error
 
     method separator->Character
-      return '/'
+      native @|#if defined(ROGUE_PLATFORM_WINDOWS)
+              |  return '\\';
+              |#else
+              |  return '/';
+              |#endif
 
     method size( filepath:String )->Int64
       native @|if ( !$filepath ) return 0;
@@ -692,7 +696,7 @@ class File
       File.ends_with_separator( this.filepath )
 
     method ensure_ends_with_separator->this
-      if (not ends_with_separator) filepath += '/'
+      if (not ends_with_separator) filepath += separator
       return this
 
     method delete->Logical [macro]

--- a/Source/Libraries/Standard/File.rogue
+++ b/Source/Libraries/Standard/File.rogue
@@ -96,10 +96,7 @@ class File
               |  char long_name[PATH_MAX+4];
               |  char full_name[PATH_MAX+4];
               |
-              |  if (GetInt64PathName((char*)$filepath->utf8, long_name, PATH_MAX+4) == 0)
-              |  {
-              |    strcpy_s( long_name, PATH_MAX+4, (char*)$filepath->utf8 );
-              |  }
+              |  strcpy_s( long_name, PATH_MAX+4, (char*)$filepath->utf8 );
               |
               |  if (GetFullPathName(long_name, PATH_MAX+4, full_name, 0) != 0)
               |  {

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -408,6 +408,15 @@ public:
 //-----------------------------------------------------------------------------
 //  Basics (Primitive types, macros, etc.)
 //-----------------------------------------------------------------------------
+#include <limits>
+#define ROGUE_R32_INFINITY       std::numeric_limits<RogueReal32>::infinity()
+#define ROGUE_R32_NEG_INFINITY (-std::numeric_limits<RogueReal32>::infinity())
+#define ROGUE_R32_NAN            std::numeric_limits<RogueReal32>::quiet_NaN()
+
+#define ROGUE_R64_INFINITY       std::numeric_limits<RogueReal64>::infinity()
+#define ROGUE_R64_NEG_INFINITY (-std::numeric_limits<RogueReal64>::infinity())
+#define ROGUE_R64_NAN            std::numeric_limits<RogueReal64>::quiet_NaN()
+
 #if defined(ROGUE_PLATFORM_WINDOWS)
   typedef double           RogueReal64;
   typedef float            RogueReal32;

--- a/Source/Libraries/Standard/NativeCPP.h
+++ b/Source/Libraries/Standard/NativeCPP.h
@@ -35,7 +35,10 @@
 #endif
 
 #if defined(ROGUE_PLATFORM_WINDOWS)
+#  define NOGDI
+#  pragma warning(disable: 4297) /* unexpected throw warnings */
 #  include <windows.h>
+#  include <signal.h>
 #else
 #  include <cstdint>
 #endif
@@ -637,6 +640,8 @@ RogueString*   RogueString_validate( RogueString* THIS );
 #define ROGUE_EMPTY_ARRAY
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define ROGUE_EMPTY_ARRAY 0
+#elif defined(ROGUE_PLATFORM_WINDOWS)
+#define ROGUE_EMPTY_ARRAY /* Okay for MSVC++ */
 #endif
 struct RogueArray : RogueObject
 {

--- a/Source/Libraries/Standard/Process.rogue
+++ b/Source/Libraries/Standard/Process.rogue
@@ -1,3 +1,6 @@
+$if target("WINDOWS")
+  $warning "Process is currently unimplemented on Windows."
+$else
 class Process
   # Loosely based on:
   # https://stackoverflow.com/questions/13893085/posix-spawnp-and-piping-child-output-to-a-string/27328610
@@ -237,6 +240,8 @@ class ProcessReader : Reader<<Byte>>
       return fd_reader.read
 
 endClass
+$endIf
+
 
 class ProcessOutput
   PROPERTIES

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -1949,6 +1949,7 @@ augment RogueC
           endIf
         endIf
 
+$if not target("WINDOWS")
         if (RogueC.pkg_config_pkgs.count)
           forEach (pkg in RogueC.pkg_config_pkgs)
             local result = Process.run("pkg-config --cflags --libs " + pkg)
@@ -1967,6 +1968,7 @@ augment RogueC
             endIf
           endForEach
         endIf
+$endIf
 
         if (RogueC.compiler_options.count)
           compiler_name += " " + " ".join(RogueC.compiler_options)

--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -2846,11 +2846,11 @@ augment CmdLiteralReal64
         if (value - value == 0)
           writer.print( value )
         else
-          if (value > 0) writer.print( "(1.0/0.0)" )   #  infinity
-          else           writer.print( "(-1.0/0.0)" )  # -infinity
+          if (value > 0) writer.print( "ROGUE_R64_INFINITY" )   #  infinity
+          else           writer.print( "ROGUE_R64_NEG_INFINITY" )  # -infinity
         endIf
       else
-        writer.print( "(0.0/0.0)" )  # NaN
+        writer.print( "ROGUE_R64_NAN" )  # NaN
       endIf
 endAugment
 
@@ -2862,11 +2862,11 @@ augment CmdLiteralReal32
         if (value - value == 0)
           writer.print( value ).print( 'f' )
         else
-          if (value > 0) writer.print( "(1.0f/0.0f)" )   #  infinity
-          else           writer.print( "(-1.0f/0.0f)" )  # -infinity
+          if (value > 0) writer.print( "ROGUE_R32_INFINITY" )   #  infinity
+          else           writer.print( "ROGUE_R32_NEG_INFINITY" )  # -infinity
         endIf
       else
-        writer.print( "(0.0f/0.0f)" )  # NaN
+        writer.print( "ROGUE_R32_NAN" )  # NaN
       endIf
 endAugment
 

--- a/Source/RogueC/Cmd.rogue
+++ b/Source/RogueC/Cmd.rogue
@@ -1599,6 +1599,13 @@ class CmdLiteralReal64 : CmdLiteralNumber
   PROPERTIES
     value : Real64
 
+  GLOBAL METHODS
+    method create_infinity( t:Token )->this
+      return CmdLiteralReal64(t, native("ROGUE_R64_INFINITY")->Real64)
+
+    method create_NaN( t:Token )->this
+      return CmdLiteralReal64(t, native("ROGUE_R64_NAN")->Real64)
+
   METHODS
     method init( t, value )
 

--- a/Source/RogueC/Parser.rogue
+++ b/Source/RogueC/Parser.rogue
@@ -3202,10 +3202,10 @@ class Parser
         return CmdLiteralReal64( t, pi )
 
       elseIf (consume(TokenType.keyword_infinity))
-        return CmdLiteralReal64( t, 1.0/0.0 )
+        return CmdLiteralReal64.create_infinity( t )
 
       elseIf (consume(TokenType.keyword_NaN))
-        return CmdLiteralReal64( t, 0.0/0.0 )
+        return CmdLiteralReal64.create_NaN( t )
 
       elseIf (consume(TokenType.symbol_open_bracket))
         # [ literal, list ]

--- a/Source/RogueC/Preprocessor.rogue
+++ b/Source/RogueC/Preprocessor.rogue
@@ -132,7 +132,7 @@ class Preprocessor
           elseIf (t.type is TokenType.directive_defined)
             local defined_word = t->String
             if (keep_tokens)
-              if (definitions.contains(defined_word))
+              if (get_definition(defined_word) is not null)
                 tokens.add( Token(TokenType.keyword_true).set_location(t) )
               else
                 tokens.add( Token(TokenType.keyword_false).set_location(t) )
@@ -407,6 +407,15 @@ class Preprocessor
       if (consume(TokenType.symbol_lt)) return parse_logical_compare( parse_logical_term >  lhs )
       return logicalize(lhs)
 
+    method get_definition( name: String )->Token[]
+      forEach (local_def in reader.local_definitions step -1)
+        local entry = local_def.find( name )
+        if (entry) return entry.value
+      endForEach
+      local entry = definitions.find( name )
+      if (entry) return entry.value
+      return null
+
     method parse_logical_term->Value
       loop
         local t = reader.peek
@@ -434,7 +443,7 @@ class Preprocessor
           must_consume(TokenType.symbol_open_paren)
           local def = reader.peek
           must_consume(TokenType.identifier)
-          local result = definitions.contains(def->String)
+          local result = get_definition(def->String) is not null
           must_consume(TokenType.symbol_close_paren)
           return result
         endIf
@@ -459,8 +468,9 @@ class Preprocessor
 
           local name = t->String
           local v = false : Value
-          local has_value = definitions.contains(name)
-          if (has_value) v = valueize(definitions[name])
+          local def = get_definition(name)
+          local has_value = def is not null
+          if (has_value) v = valueize(def)
           if (v is null) throw reader.peek.error( "Definition '$' does not have a legal value for preprocessor expressions." (name) )
 
           if (reader.peek->String == "?")


### PR DESCRIPTION
The first couple commits are tweaks/fixes.

The rest are basically all around increasing portability, specifically with a mind towards supporting Windows.  After applying, building a Windows compiler which builds at least basic Rogue code is possible (targeting Visual Studio 2017's compiler).  It hasn't been tested extensively.

When building Windows software, you must currently:
1. `--define=CONSOLE_BAREBONES` (the full Console class is unsupported)
2. `--target=C++,WINDOWS` (among other things, this disable Process which is unsupported)
3. Not use `--compile` or `--execute` (you have to manually invoke the C++ compiler...)
3. Compile the generated .cpp with `cl foo.cpp /EHsc`

Currently, there's no support for actually building/bootstrapping roguec from Windows.  Compile the .cpp/.h on macOS/Linux (using the rules for building Windows code above!).  Then compile that using MSVC++ on Windows (again, as specified above).

You may also need to explicitly specify where the Windows version can find libraries using `--libraries` when compiling on Windows; I don't really know.

To bootstrap this, first compile 01fc55e to fix the preprocessor; this is needed to compile the new code in Console (8e5cc98).