### PR TITLE
CPPWriter: Fix dynamic method callers

### DIFF
--- a/Source/RogueC/CPPWriter.rogue
+++ b/Source/RogueC/CPPWriter.rogue
@@ -324,9 +324,17 @@ augment Program
 
       # write dynamic dispatch method prototypes
       if (RogueC.all_methods_callable_dynamically)
-        forEach (sig in native_method_signature_list)
-          local m = native_method_signature_lookup[sig]  # one of the methods using this signature
-          if (m.called_dynamically or RogueC.all_methods_callable_dynamically)
+        local done = Set<<String>>()
+        forEach (type in type_list)
+          if (not type.method_list) nextIteration
+          forEach (m in type.method_list)
+            if (not m.cpp_typedef) nextIteration
+            if (not m.is_c_compatible) nextIteration
+            if (not m.type_context) nextIteration
+            if (not m.type_context.is_reference) nextIteration
+            if (done.contains(m.cpp_typedef)) nextIteration
+            done.add(m.cpp_typedef)
+
             writer.print_export( m )
             if (m.return_type and m.return_type.is_reference) writer.print( "void*" )
             else                                              writer.print( m.return_type )
@@ -340,7 +348,7 @@ augment Program
               writer.print( " p" ).print( i )
             endForEach
             writer.println( " );" )
-          endIf
+          endForEach
         endForEach
         writer.println
       endIf


### PR DESCRIPTION
Dynamic caller function generation folds together functions with
similar prototypes.  A problematic example was that a global method
with a reference first parameter and X additional parameters folded
to the same thing as a non-global method with X parameters.  When
creating the dynamic callers, we iterated through the signatures and
picked a *somewhat* arbitrary method with the signature as the basis
for constructing the caller.  However, this might be a global method,
and we'd end up generating the caller with an extra argument.

We could have fixed this by being more careful about which method
actually ends up being associated with the signature in the
determine_cpp_method_typedefs() method (it shouldn't be global).
But this seems brittle and annoying.

Instead, the actual generation of dynamic callers now iterates through
every method (instead of every unique signature), determines if it's a
method it wants to create a caller for using its own local criteria,
and remembers the signatures of the ones it has done already so that
additional folded ones are skipped.  This requires more iterations, of
course, but doesn't seem to particularly affect compilation time.